### PR TITLE
fix: inherit generated AnalyticsResource to expose MCP methods

### DIFF
--- a/src/late/resources/analytics.py
+++ b/src/late/resources/analytics.py
@@ -1,28 +1,38 @@
 """
 Analytics resource for post analytics and usage statistics.
+
+Inherits all generated analytics methods (get_analytics, get_daily_metrics,
+get_best_time_to_post, etc.) and adds convenience aliases.
 """
 
 from __future__ import annotations
 
 from typing import Any, Literal
 
-from .base import BaseResource
+from ._generated.analytics import AnalyticsResource as _GeneratedAnalyticsResource
 
 Period = Literal["7d", "30d", "90d", "all"]
 
 
-class AnalyticsResource(BaseResource[Any]):
+class AnalyticsResource(_GeneratedAnalyticsResource):
     """
     Resource for analytics and usage statistics.
 
+    Inherits all generated analytics methods (get_analytics, get_daily_metrics,
+    get_best_time_to_post, etc.) and adds convenience aliases for backwards
+    compatibility with existing SDK users.
+
     Example:
         >>> client = Late(api_key="...")
-        >>> # Get post analytics
+        >>> # Get post analytics (generated method, used by MCP tools)
+        >>> analytics = client.analytics.get_analytics(period="30d")
+        >>> # Get post analytics (convenience alias)
         >>> analytics = client.analytics.get(period="30d")
         >>> # Get usage statistics
         >>> usage = client.analytics.get_usage()
     """
 
+    # Used by convenience get()/aget() methods below
     _BASE_PATH = "/v1/analytics"
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- All 9 analytics MCP tools (`get_analytics`, `get_daily_metrics`, `get_best_time_to_post`, `get_content_decay`, `get_posting_frequency`, `get_post_timeline`, `get_you_tube_daily_views`, `get_linked_in_aggregate_analytics`, `get_linked_in_post_analytics`) failed with `AttributeError: 'AnalyticsResource' object has no attribute 'get_analytics'`
- Root cause: manual `AnalyticsResource` (inheriting `BaseResource[Any]`) shadowed the generated class that has all 18 methods MCP tools expect
- Fix: change parent class from `BaseResource[Any]` to the generated `AnalyticsResource`, exposing all generated methods via inheritance while preserving `get()`/`get_usage()` convenience aliases for existing SDK users

## Test plan
- [x] AST verification: 25 total methods available (4 manual + 21 generated), zero overlaps
- [x] Import chain verified: client → `__init__` → manual → generated (no circular imports)
- [x] `_build_params` compatibility confirmed (functionally identical implementations)
- [x] `__init__` compatibility confirmed (identical signatures)
- [x] No `isinstance(x, BaseResource)` checks in tests
- [x] `_BASE_PATH` preserved for convenience methods, no conflict with generated class
- [x] 157 tests passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)