### PR TITLE
fix: add zernio-mcp executable and rebrand package to zernio-sdk

### DIFF
--- a/claude-desktop-config.json
+++ b/claude-desktop-config.json
@@ -1,15 +1,12 @@
 {
   "mcpServers": {
-    "late": {
-      "command": "uv",
+    "zernio": {
+      "command": "uvx",
       "args": [
-        "run",
-        "--directory",
-        "/Users/carlos/Documents/WebDev/Freelance/miquel-palet/late-python-starter",
-        "late-mcp"
+        "zernio-mcp"
       ],
       "env": {
-        "LATE_API_KEY": "YOUR_API_KEY_HERE"
+        "ZERNIO_API_KEY": "YOUR_API_KEY_HERE"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [project]
-name = "late-sdk"
-version = "1.2.91"
-description = "The official Python library for the Late API"
+name = "zernio-sdk"
+version = "1.2.92"
+description = "The official Python library for the Zernio API"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
-    { name = "Late", email = "hello@zernio.com" }
+    { name = "Zernio", email = "hello@zernio.com" }
 ]
 keywords = [
+    "zernio",
     "late",
     "social-media",
     "scheduling",
@@ -77,6 +78,10 @@ dev = [
 ]
 
 [project.scripts]
+# New Zernio-branded entry points
+zernio-mcp = "late.mcp.server:main"
+zernio-mcp-http = "late.mcp.http_server:main"
+# Backward-compatible entry points (kept for existing users)
 late-mcp = "late.mcp.server:main"
 late-mcp-http = "late.mcp.http_server:main"
 


### PR DESCRIPTION
## Summary\n\n- **Rename package** from `late-sdk` to `zernio-sdk` (version bump to 1.2.92)\n- **Add `zernio-mcp` and `zernio-mcp-http`** script entry points so `uvx zernio-mcp` works\n- **Keep `late-mcp` and `late-mcp-http`** for backward compatibility\n- **Update metadata**: description, author name, keywords to reflect Zernio branding\n- **Update `claude-desktop-config.json`** example to use `zernio-mcp`\n\n## Context\n\nA user reported that `uvx zernio-mcp` fails with:\n```\nAn executable named `zernio-mcp` is not provided by package `zernio-sdk`.\nThe following executables are available:\n- late-mcp\n- late-mcp-http\n```\n\nThe package was rebranded on PyPI but the `[project.scripts]` in `pyproject.toml` still only registered the old `late-mcp` entry points.\n\n## Test plan\n\n- [ ] After publishing, verify `uvx zernio-mcp` starts the MCP server\n- [ ] Verify `uvx late-mcp` still works (backward compat)\n- [ ] Verify `pip install zernio-sdk` installs both executables