### PR TITLE
fix: use snake_case kwargs in MCP tool handlers

### DIFF
--- a/scripts/generate_mcp_tools.py
+++ b/scripts/generate_mcp_tools.py
@@ -186,7 +186,7 @@ def extract_parameters(operation: dict[str, Any]) -> list[dict[str, Any]]:
                 "required": is_required,
                 "default": default_str,
                 "description": prop_schema.get("description", ""),
-                "sdk_name": prop_name,
+                "sdk_name": py_name,
             })
 
     return params

--- a/src/late/mcp/generated_tools.py
+++ b/src/late/mcp/generated_tools.py
@@ -13,37 +13,35 @@ def _format_response(response: Any) -> str:
     """Format SDK response for MCP output."""
     if response is None:
         return "Success"
-    if hasattr(response, "__dict__"):
+    if hasattr(response, '__dict__'):
         # Handle response objects
-        if hasattr(response, "posts") and response.posts:
+        if hasattr(response, 'posts') and response.posts:
             posts = response.posts
             lines = [f"Found {len(posts)} post(s):"]
             for p in posts[:10]:
-                content = str(getattr(p, "content", ""))[:50]
-                status = getattr(p, "status", "unknown")
+                content = str(getattr(p, 'content', ''))[:50]
+                status = getattr(p, 'status', 'unknown')
                 lines.append(f"- [{status}] {content}...")
             return "\n".join(lines)
-        if hasattr(response, "accounts") and response.accounts:
+        if hasattr(response, 'accounts') and response.accounts:
             accs = response.accounts
             lines = [f"Found {len(accs)} account(s):"]
             for a in accs[:10]:
-                platform = getattr(a, "platform", "?")
-                username = getattr(a, "username", None) or getattr(
-                    a, "displayName", "?"
-                )
+                platform = getattr(a, 'platform', '?')
+                username = getattr(a, 'username', None) or getattr(a, 'displayName', '?')
                 lines.append(f"- {platform}: {username}")
             return "\n".join(lines)
-        if hasattr(response, "profiles") and response.profiles:
+        if hasattr(response, 'profiles') and response.profiles:
             profiles = response.profiles
             lines = [f"Found {len(profiles)} profile(s):"]
             for p in profiles[:10]:
-                name = getattr(p, "name", "Unnamed")
+                name = getattr(p, 'name', 'Unnamed')
                 lines.append(f"- {name}")
             return "\n".join(lines)
-        if hasattr(response, "post") and response.post:
+        if hasattr(response, 'post') and response.post:
             p = response.post
             return f"Post ID: {getattr(p, 'field_id', 'N/A')}\nStatus: {getattr(p, 'status', 'N/A')}"
-        if hasattr(response, "profile") and response.profile:
+        if hasattr(response, 'profile') and response.profile:
             p = response.profile
             return f"Profile: {getattr(p, 'name', 'N/A')} (ID: {getattr(p, 'field_id', 'N/A')})"
     return str(response)
@@ -54,6 +52,7 @@ def register_generated_tools(mcp, _get_client):
 
     # ACCOUNT_GROUPS
 
+
     @mcp.tool()
     def account_groups_list_account_groups() -> str:
         """List groups"""
@@ -62,7 +61,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.account_groups.list_account_groups()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_groups_create_account_group(name: str, account_ids: str) -> str:
@@ -73,17 +73,14 @@ def register_generated_tools(mcp, _get_client):
             account_ids: (required)"""
         client = _get_client()
         try:
-            response = client.account_groups.create_account_group(
-                name=name, accountIds=account_ids
-            )
+            response = client.account_groups.create_account_group(name=name, account_ids=account_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def account_groups_update_account_group(
-        group_id: str, name: str = "", account_ids: str = ""
-    ) -> str:
+    def account_groups_update_account_group(group_id: str, name: str = "", account_ids: str = "") -> str:
         """Update group
 
         Args:
@@ -92,12 +89,11 @@ def register_generated_tools(mcp, _get_client):
             account_ids"""
         client = _get_client()
         try:
-            response = client.account_groups.update_account_group(
-                group_id=group_id, name=name, accountIds=account_ids
-            )
+            response = client.account_groups.update_account_group(group_id=group_id, name=name, account_ids=account_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_groups_delete_account_group(group_id: str) -> str:
@@ -110,9 +106,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.account_groups.delete_account_group(group_id=group_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # ACCOUNT_SETTINGS
+
 
     @mcp.tool()
     def account_settings_get_messenger_menu(account_id: str) -> str:
@@ -125,12 +122,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.account_settings.get_messenger_menu(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def account_settings_set_messenger_menu(
-        account_id: str, persistent_menu: str
-    ) -> str:
+    def account_settings_set_messenger_menu(account_id: str, persistent_menu: str) -> str:
         """Set FB persistent menu
 
         Args:
@@ -138,12 +134,11 @@ def register_generated_tools(mcp, _get_client):
             persistent_menu: Persistent menu configuration array (Meta format) (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.set_messenger_menu(
-                account_id=account_id, persistent_menu=persistent_menu
-            )
+            response = client.account_settings.set_messenger_menu(account_id=account_id, persistent_menu=persistent_menu)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_delete_messenger_menu(account_id: str) -> str:
@@ -153,12 +148,11 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.delete_messenger_menu(
-                account_id=account_id
-            )
+            response = client.account_settings.delete_messenger_menu(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_get_instagram_ice_breakers(account_id: str) -> str:
@@ -168,17 +162,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.get_instagram_ice_breakers(
-                account_id=account_id
-            )
+            response = client.account_settings.get_instagram_ice_breakers(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def account_settings_set_instagram_ice_breakers(
-        account_id: str, ice_breakers: str
-    ) -> str:
+    def account_settings_set_instagram_ice_breakers(account_id: str, ice_breakers: str) -> str:
         """Set IG ice breakers
 
         Args:
@@ -186,12 +177,11 @@ def register_generated_tools(mcp, _get_client):
             ice_breakers: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.set_instagram_ice_breakers(
-                account_id=account_id, ice_breakers=ice_breakers
-            )
+            response = client.account_settings.set_instagram_ice_breakers(account_id=account_id, ice_breakers=ice_breakers)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_delete_instagram_ice_breakers(account_id: str) -> str:
@@ -201,12 +191,11 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.delete_instagram_ice_breakers(
-                account_id=account_id
-            )
+            response = client.account_settings.delete_instagram_ice_breakers(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_get_telegram_commands(account_id: str) -> str:
@@ -216,12 +205,11 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.get_telegram_commands(
-                account_id=account_id
-            )
+            response = client.account_settings.get_telegram_commands(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_set_telegram_commands(account_id: str, commands: str) -> str:
@@ -232,12 +220,11 @@ def register_generated_tools(mcp, _get_client):
             commands: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.set_telegram_commands(
-                account_id=account_id, commands=commands
-            )
+            response = client.account_settings.set_telegram_commands(account_id=account_id, commands=commands)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def account_settings_delete_telegram_commands(account_id: str) -> str:
@@ -247,19 +234,16 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.account_settings.delete_telegram_commands(
-                account_id=account_id
-            )
+            response = client.account_settings.delete_telegram_commands(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # ACCOUNTS
 
+
     @mcp.tool()
-    def accounts_list_accounts(
-        profile_id: str = "", platform: str = "", include_over_limit: bool = False
-    ) -> str:
+    def accounts_list_accounts(profile_id: str = "", platform: str = "", include_over_limit: bool = False) -> str:
         """List accounts
 
         Args:
@@ -268,23 +252,14 @@ def register_generated_tools(mcp, _get_client):
             include_over_limit: When true, includes accounts from over-limit profiles."""
         client = _get_client()
         try:
-            response = client.accounts.list_accounts(
-                profile_id=profile_id,
-                platform=platform,
-                include_over_limit=include_over_limit,
-            )
+            response = client.accounts.list_accounts(profile_id=profile_id, platform=platform, include_over_limit=include_over_limit)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_follower_stats(
-        account_ids: str = "",
-        profile_id: str = "",
-        from_date: str = "",
-        to_date: str = "",
-        granularity: str = "daily",
-    ) -> str:
+    def accounts_get_follower_stats(account_ids: str = "", profile_id: str = "", from_date: str = "", to_date: str = "", granularity: str = "daily") -> str:
         """Get follower stats
 
         Args:
@@ -295,21 +270,14 @@ def register_generated_tools(mcp, _get_client):
             granularity: Data aggregation level"""
         client = _get_client()
         try:
-            response = client.accounts.get_follower_stats(
-                account_ids=account_ids,
-                profile_id=profile_id,
-                from_date=from_date,
-                to_date=to_date,
-                granularity=granularity,
-            )
+            response = client.accounts.get_follower_stats(account_ids=account_ids, profile_id=profile_id, from_date=from_date, to_date=to_date, granularity=granularity)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_update_account(
-        account_id: str, username: str = "", display_name: str = ""
-    ) -> str:
+    def accounts_update_account(account_id: str, username: str = "", display_name: str = "") -> str:
         """Update account
 
         Args:
@@ -318,12 +286,11 @@ def register_generated_tools(mcp, _get_client):
             display_name"""
         client = _get_client()
         try:
-            response = client.accounts.update_account(
-                account_id=account_id, username=username, displayName=display_name
-            )
+            response = client.accounts.update_account(account_id=account_id, username=username, display_name=display_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def accounts_delete_account(account_id: str) -> str:
@@ -336,12 +303,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.accounts.delete_account(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_all_accounts_health(
-        profile_id: str = "", platform: str = "", status: str = ""
-    ) -> str:
+    def accounts_get_all_accounts_health(profile_id: str = "", platform: str = "", status: str = "") -> str:
         """Check accounts health
 
         Args:
@@ -350,12 +316,11 @@ def register_generated_tools(mcp, _get_client):
             status: Filter by health status"""
         client = _get_client()
         try:
-            response = client.accounts.get_all_accounts_health(
-                profile_id=profile_id, platform=platform, status=status
-            )
+            response = client.accounts.get_all_accounts_health(profile_id=profile_id, platform=platform, status=status)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def accounts_get_account_health(account_id: str) -> str:
@@ -368,12 +333,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.accounts.get_account_health(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_tik_tok_creator_info(
-        account_id: str, media_type: str = "video"
-    ) -> str:
+    def accounts_get_tik_tok_creator_info(account_id: str, media_type: str = "video") -> str:
         """Get TikTok creator info
 
         Args:
@@ -381,20 +345,14 @@ def register_generated_tools(mcp, _get_client):
             media_type: The media type to get creator info for (affects available interaction settings)"""
         client = _get_client()
         try:
-            response = client.accounts.get_tik_tok_creator_info(
-                account_id=account_id, media_type=media_type
-            )
+            response = client.accounts.get_tik_tok_creator_info(account_id=account_id, media_type=media_type)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_google_business_reviews(
-        account_id: str,
-        location_id: str = "",
-        page_size: int = 50,
-        page_token: str = "",
-    ) -> str:
+    def accounts_get_google_business_reviews(account_id: str, location_id: str = "", page_size: int = 50, page_token: str = "") -> str:
         """Get reviews
 
         Args:
@@ -404,20 +362,14 @@ def register_generated_tools(mcp, _get_client):
             page_token: Pagination token from previous response"""
         client = _get_client()
         try:
-            response = client.accounts.get_google_business_reviews(
-                account_id=account_id,
-                location_id=location_id,
-                page_size=page_size,
-                page_token=page_token,
-            )
+            response = client.accounts.get_google_business_reviews(account_id=account_id, location_id=location_id, page_size=page_size, page_token=page_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_google_business_food_menus(
-        account_id: str, location_id: str = ""
-    ) -> str:
+    def accounts_get_google_business_food_menus(account_id: str, location_id: str = "") -> str:
         """Get food menus
 
         Args:
@@ -425,17 +377,14 @@ def register_generated_tools(mcp, _get_client):
             location_id: Override which location to query. If omitted, uses the account's selected location. Use GET /gmb-locations to list valid IDs."""
         client = _get_client()
         try:
-            response = client.accounts.get_google_business_food_menus(
-                account_id=account_id, location_id=location_id
-            )
+            response = client.accounts.get_google_business_food_menus(account_id=account_id, location_id=location_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_update_google_business_food_menus(
-        account_id: str, menus: str, location_id: str = "", update_mask: str = ""
-    ) -> str:
+    def accounts_update_google_business_food_menus(account_id: str, menus: str, location_id: str = "", update_mask: str = "") -> str:
         """Update food menus
 
         Args:
@@ -445,20 +394,14 @@ def register_generated_tools(mcp, _get_client):
             update_mask: Field mask for partial updates (e.g. "menus")"""
         client = _get_client()
         try:
-            response = client.accounts.update_google_business_food_menus(
-                account_id=account_id,
-                location_id=location_id,
-                menus=menus,
-                updateMask=update_mask,
-            )
+            response = client.accounts.update_google_business_food_menus(account_id=account_id, location_id=location_id, menus=menus, update_mask=update_mask)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_google_business_location_details(
-        account_id: str, location_id: str = "", read_mask: str = ""
-    ) -> str:
+    def accounts_get_google_business_location_details(account_id: str, location_id: str = "", read_mask: str = "") -> str:
         """Get location details
 
         Args:
@@ -467,26 +410,14 @@ def register_generated_tools(mcp, _get_client):
             read_mask: Comma-separated fields to return. Available: name, title, phoneNumbers, categories, storefrontAddress, websiteUri, regularHours, specialHours, serviceArea, serviceItems, profile, openInfo, metadata, moreHours."""
         client = _get_client()
         try:
-            response = client.accounts.get_google_business_location_details(
-                account_id=account_id, location_id=location_id, read_mask=read_mask
-            )
+            response = client.accounts.get_google_business_location_details(account_id=account_id, location_id=location_id, read_mask=read_mask)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_update_google_business_location_details(
-        account_id: str,
-        update_mask: str,
-        location_id: str = "",
-        regular_hours: str = "",
-        special_hours: str = "",
-        profile: str = "",
-        website_uri: str = "",
-        phone_numbers: str = "",
-        categories: str = "",
-        service_items: str = "",
-    ) -> str:
+    def accounts_update_google_business_location_details(account_id: str, update_mask: str, location_id: str = "", regular_hours: str = "", special_hours: str = "", profile: str = "", website_uri: str = "", phone_numbers: str = "", categories: str = "", service_items: str = "") -> str:
         """Update location details
 
         Args:
@@ -502,29 +433,14 @@ def register_generated_tools(mcp, _get_client):
             service_items: Services offered by the business. Use updateMask='serviceItems' to update."""
         client = _get_client()
         try:
-            response = client.accounts.update_google_business_location_details(
-                account_id=account_id,
-                location_id=location_id,
-                updateMask=update_mask,
-                regularHours=regular_hours,
-                specialHours=special_hours,
-                profile=profile,
-                websiteUri=website_uri,
-                phoneNumbers=phone_numbers,
-                categories=categories,
-                serviceItems=service_items,
-            )
+            response = client.accounts.update_google_business_location_details(account_id=account_id, location_id=location_id, update_mask=update_mask, regular_hours=regular_hours, special_hours=special_hours, profile=profile, website_uri=website_uri, phone_numbers=phone_numbers, categories=categories, service_items=service_items)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_list_google_business_media(
-        account_id: str,
-        location_id: str = "",
-        page_size: int = 100,
-        page_token: str = "",
-    ) -> str:
+    def accounts_list_google_business_media(account_id: str, location_id: str = "", page_size: int = 100, page_token: str = "") -> str:
         """List media
 
         Args:
@@ -534,25 +450,14 @@ def register_generated_tools(mcp, _get_client):
             page_token: Pagination token from previous response"""
         client = _get_client()
         try:
-            response = client.accounts.list_google_business_media(
-                account_id=account_id,
-                location_id=location_id,
-                page_size=page_size,
-                page_token=page_token,
-            )
+            response = client.accounts.list_google_business_media(account_id=account_id, location_id=location_id, page_size=page_size, page_token=page_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_create_google_business_media(
-        account_id: str,
-        source_url: str,
-        location_id: str = "",
-        media_format: str = "PHOTO",
-        description: str = "",
-        category: str = "",
-    ) -> str:
+    def accounts_create_google_business_media(account_id: str, source_url: str, location_id: str = "", media_format: str = "PHOTO", description: str = "", category: str = "") -> str:
         """Upload photo
 
         Args:
@@ -564,22 +469,14 @@ def register_generated_tools(mcp, _get_client):
             category: Where the photo appears on the listing"""
         client = _get_client()
         try:
-            response = client.accounts.create_google_business_media(
-                account_id=account_id,
-                location_id=location_id,
-                sourceUrl=source_url,
-                mediaFormat=media_format,
-                description=description,
-                category=category,
-            )
+            response = client.accounts.create_google_business_media(account_id=account_id, location_id=location_id, source_url=source_url, media_format=media_format, description=description, category=category)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_delete_google_business_media(
-        account_id: str, media_id: str, location_id: str = ""
-    ) -> str:
+    def accounts_delete_google_business_media(account_id: str, media_id: str, location_id: str = "") -> str:
         """Delete photo
 
         Args:
@@ -588,17 +485,14 @@ def register_generated_tools(mcp, _get_client):
             media_id: The media item ID to delete (required)"""
         client = _get_client()
         try:
-            response = client.accounts.delete_google_business_media(
-                account_id=account_id, location_id=location_id, media_id=media_id
-            )
+            response = client.accounts.delete_google_business_media(account_id=account_id, location_id=location_id, media_id=media_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_google_business_attributes(
-        account_id: str, location_id: str = ""
-    ) -> str:
+    def accounts_get_google_business_attributes(account_id: str, location_id: str = "") -> str:
         """Get attributes
 
         Args:
@@ -606,17 +500,14 @@ def register_generated_tools(mcp, _get_client):
             location_id: Override which location to query. If omitted, uses the account's selected location. Use GET /gmb-locations to list valid IDs."""
         client = _get_client()
         try:
-            response = client.accounts.get_google_business_attributes(
-                account_id=account_id, location_id=location_id
-            )
+            response = client.accounts.get_google_business_attributes(account_id=account_id, location_id=location_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_update_google_business_attributes(
-        account_id: str, attributes: str, attribute_mask: str, location_id: str = ""
-    ) -> str:
+    def accounts_update_google_business_attributes(account_id: str, attributes: str, attribute_mask: str, location_id: str = "") -> str:
         """Update attributes
 
         Args:
@@ -626,23 +517,14 @@ def register_generated_tools(mcp, _get_client):
             attribute_mask: Comma-separated attribute names to update (e.g. 'has_delivery,has_takeout') (required)"""
         client = _get_client()
         try:
-            response = client.accounts.update_google_business_attributes(
-                account_id=account_id,
-                location_id=location_id,
-                attributes=attributes,
-                attributeMask=attribute_mask,
-            )
+            response = client.accounts.update_google_business_attributes(account_id=account_id, location_id=location_id, attributes=attributes, attribute_mask=attribute_mask)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_list_google_business_place_actions(
-        account_id: str,
-        location_id: str = "",
-        page_size: int = 100,
-        page_token: str = "",
-    ) -> str:
+    def accounts_list_google_business_place_actions(account_id: str, location_id: str = "", page_size: int = 100, page_token: str = "") -> str:
         """List action links
 
         Args:
@@ -652,20 +534,14 @@ def register_generated_tools(mcp, _get_client):
             page_token"""
         client = _get_client()
         try:
-            response = client.accounts.list_google_business_place_actions(
-                account_id=account_id,
-                location_id=location_id,
-                page_size=page_size,
-                page_token=page_token,
-            )
+            response = client.accounts.list_google_business_place_actions(account_id=account_id, location_id=location_id, page_size=page_size, page_token=page_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_create_google_business_place_action(
-        account_id: str, uri: str, place_action_type: str, location_id: str = ""
-    ) -> str:
+    def accounts_create_google_business_place_action(account_id: str, uri: str, place_action_type: str, location_id: str = "") -> str:
         """Create action link
 
         Args:
@@ -675,20 +551,14 @@ def register_generated_tools(mcp, _get_client):
             place_action_type: Type of action (required)"""
         client = _get_client()
         try:
-            response = client.accounts.create_google_business_place_action(
-                account_id=account_id,
-                location_id=location_id,
-                uri=uri,
-                placeActionType=place_action_type,
-            )
+            response = client.accounts.create_google_business_place_action(account_id=account_id, location_id=location_id, uri=uri, place_action_type=place_action_type)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_delete_google_business_place_action(
-        account_id: str, name: str, location_id: str = ""
-    ) -> str:
+    def accounts_delete_google_business_place_action(account_id: str, name: str, location_id: str = "") -> str:
         """Delete action link
 
         Args:
@@ -697,17 +567,14 @@ def register_generated_tools(mcp, _get_client):
             name: The resource name of the place action link (e.g. locations/123/placeActionLinks/456) (required)"""
         client = _get_client()
         try:
-            response = client.accounts.delete_google_business_place_action(
-                account_id=account_id, location_id=location_id, name=name
-            )
+            response = client.accounts.delete_google_business_place_action(account_id=account_id, location_id=location_id, name=name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def accounts_get_linked_in_mentions(
-        account_id: str, url: str, display_name: str = ""
-    ) -> str:
+    def accounts_get_linked_in_mentions(account_id: str, url: str, display_name: str = "") -> str:
         """Resolve LinkedIn mention
 
         Args:
@@ -716,29 +583,16 @@ def register_generated_tools(mcp, _get_client):
             display_name: Exact display name as shown on LinkedIn. Required for person mentions to be clickable. Optional for org mentions."""
         client = _get_client()
         try:
-            response = client.accounts.get_linked_in_mentions(
-                account_id=account_id, url=url, display_name=display_name
-            )
+            response = client.accounts.get_linked_in_mentions(account_id=account_id, url=url, display_name=display_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # ANALYTICS
 
+
     @mcp.tool()
-    def analytics_get_analytics(
-        post_id: str = "",
-        platform: str = "",
-        profile_id: str = "",
-        account_id: str = "",
-        source: str = "all",
-        from_date: str = "",
-        to_date: str = "",
-        limit: int = 50,
-        page: int = 1,
-        sort_by: str = "date",
-        order: str = "desc",
-    ) -> str:
+    def analytics_get_analytics(post_id: str = "", platform: str = "", profile_id: str = "", account_id: str = "", source: str = "all", from_date: str = "", to_date: str = "", limit: int = 50, page: int = 1, sort_by: str = "date", order: str = "desc") -> str:
         """Get post analytics
 
         Args:
@@ -755,27 +609,14 @@ def register_generated_tools(mcp, _get_client):
             order: Sort order"""
         client = _get_client()
         try:
-            response = client.analytics.get_analytics(
-                post_id=post_id,
-                platform=platform,
-                profile_id=profile_id,
-                account_id=account_id,
-                source=source,
-                from_date=from_date,
-                to_date=to_date,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                order=order,
-            )
+            response = client.analytics.get_analytics(post_id=post_id, platform=platform, profile_id=profile_id, account_id=account_id, source=source, from_date=from_date, to_date=to_date, limit=limit, page=page, sort_by=sort_by, order=order)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_you_tube_daily_views(
-        video_id: str, account_id: str, start_date: str = "", end_date: str = ""
-    ) -> str:
+    def analytics_get_you_tube_daily_views(video_id: str, account_id: str, start_date: str = "", end_date: str = "") -> str:
         """Get YouTube daily views
 
         Args:
@@ -785,89 +626,56 @@ def register_generated_tools(mcp, _get_client):
             end_date: End date (YYYY-MM-DD). Defaults to 3 days ago (YouTube data latency)."""
         client = _get_client()
         try:
-            response = client.analytics.get_you_tube_daily_views(
-                video_id=video_id,
-                account_id=account_id,
-                start_date=start_date,
-                end_date=end_date,
-            )
+            response = client.analytics.get_you_tube_daily_views(video_id=video_id, account_id=account_id, start_date=start_date, end_date=end_date)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_instagram_account_insights(
-        account_id: str,
-        metrics: str = "",
-        since: str = "",
-        until: str = "",
-        metric_type: str = "total_value",
-        breakdown: str = "",
-    ) -> str:
+    def analytics_get_instagram_account_insights(account_id: str, metrics: str = "", since: str = "", until: str = "", metric_type: str = "total_value", breakdown: str = "") -> str:
         """Get Instagram account-level insights
 
-            Args:
-                account_id: The Zernio SocialAccount ID for the Instagram account (required)
-                metrics: Comma-separated list of metrics. Defaults to "reach,views,accounts_engaged,total_interactions".
-        Valid metrics: reach, views, accounts_engaged, total_interactions, comments, likes, saves, shares,
-        replies, reposts, follows_and_unfollows, profile_links_taps.
-        Note: only "reach" supports metricType=time_series. All other metrics are total_value only.
-                since: Start date (YYYY-MM-DD). Defaults to 30 days ago.
-                until: End date (YYYY-MM-DD). Defaults to today.
-                metric_type: "total_value" (default) returns aggregated totals and supports breakdowns.
-        "time_series" returns daily values but only works with the "reach" metric.
-                breakdown: Breakdown dimension (only valid with metricType=total_value).
-        Valid values depend on the metric: media_product_type, follow_type, follower_type, contact_button_type."""
+        Args:
+            account_id: The Zernio SocialAccount ID for the Instagram account (required)
+            metrics: Comma-separated list of metrics. Defaults to "reach,views,accounts_engaged,total_interactions".
+    Valid metrics: reach, views, accounts_engaged, total_interactions, comments, likes, saves, shares,
+    replies, reposts, follows_and_unfollows, profile_links_taps.
+    Note: only "reach" supports metricType=time_series. All other metrics are total_value only.
+            since: Start date (YYYY-MM-DD). Defaults to 30 days ago.
+            until: End date (YYYY-MM-DD). Defaults to today.
+            metric_type: "total_value" (default) returns aggregated totals and supports breakdowns.
+    "time_series" returns daily values but only works with the "reach" metric.
+            breakdown: Breakdown dimension (only valid with metricType=total_value).
+    Valid values depend on the metric: media_product_type, follow_type, follower_type, contact_button_type."""
         client = _get_client()
         try:
-            response = client.analytics.get_instagram_account_insights(
-                account_id=account_id,
-                metrics=metrics,
-                since=since,
-                until=until,
-                metric_type=metric_type,
-                breakdown=breakdown,
-            )
+            response = client.analytics.get_instagram_account_insights(account_id=account_id, metrics=metrics, since=since, until=until, metric_type=metric_type, breakdown=breakdown)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_instagram_demographics(
-        account_id: str,
-        metric: str = "follower_demographics",
-        breakdown: str = "",
-        timeframe: str = "this_month",
-    ) -> str:
+    def analytics_get_instagram_demographics(account_id: str, metric: str = "follower_demographics", breakdown: str = "", timeframe: str = "this_month") -> str:
         """Get Instagram audience demographics
 
-            Args:
-                account_id: The Zernio SocialAccount ID for the Instagram account (required)
-                metric: "follower_demographics" for follower audience data, or "engaged_audience_demographics" for engaged viewers.
-                breakdown: Comma-separated list of demographic dimensions: age, city, country, gender.
-        Defaults to all four if omitted.
-                timeframe: Time period for demographic data. Defaults to "this_month"."""
+        Args:
+            account_id: The Zernio SocialAccount ID for the Instagram account (required)
+            metric: "follower_demographics" for follower audience data, or "engaged_audience_demographics" for engaged viewers.
+            breakdown: Comma-separated list of demographic dimensions: age, city, country, gender.
+    Defaults to all four if omitted.
+            timeframe: Time period for demographic data. Defaults to "this_month"."""
         client = _get_client()
         try:
-            response = client.analytics.get_instagram_demographics(
-                account_id=account_id,
-                metric=metric,
-                breakdown=breakdown,
-                timeframe=timeframe,
-            )
+            response = client.analytics.get_instagram_demographics(account_id=account_id, metric=metric, breakdown=breakdown, timeframe=timeframe)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_daily_metrics(
-        platform: str = "",
-        profile_id: str = "",
-        account_id: str = "",
-        from_date: str = "",
-        to_date: str = "",
-        source: str = "all",
-    ) -> str:
+    def analytics_get_daily_metrics(platform: str = "", profile_id: str = "", account_id: str = "", from_date: str = "", to_date: str = "", source: str = "all") -> str:
         """Get daily aggregated metrics
 
         Args:
@@ -879,22 +687,14 @@ def register_generated_tools(mcp, _get_client):
             source: Filter by post origin. "late" for posts published via Zernio, "external" for posts imported from platforms."""
         client = _get_client()
         try:
-            response = client.analytics.get_daily_metrics(
-                platform=platform,
-                profile_id=profile_id,
-                account_id=account_id,
-                from_date=from_date,
-                to_date=to_date,
-                source=source,
-            )
+            response = client.analytics.get_daily_metrics(platform=platform, profile_id=profile_id, account_id=account_id, from_date=from_date, to_date=to_date, source=source)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_best_time_to_post(
-        platform: str = "", profile_id: str = "", source: str = "all"
-    ) -> str:
+    def analytics_get_best_time_to_post(platform: str = "", profile_id: str = "", source: str = "all") -> str:
         """Get best times to post
 
         Args:
@@ -903,17 +703,14 @@ def register_generated_tools(mcp, _get_client):
             source: Filter by post origin. "late" for posts published via Zernio, "external" for posts imported from platforms."""
         client = _get_client()
         try:
-            response = client.analytics.get_best_time_to_post(
-                platform=platform, profile_id=profile_id, source=source
-            )
+            response = client.analytics.get_best_time_to_post(platform=platform, profile_id=profile_id, source=source)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_content_decay(
-        platform: str = "", profile_id: str = "", source: str = "all"
-    ) -> str:
+    def analytics_get_content_decay(platform: str = "", profile_id: str = "", source: str = "all") -> str:
         """Get content performance decay
 
         Args:
@@ -922,17 +719,14 @@ def register_generated_tools(mcp, _get_client):
             source: Filter by post origin. "late" for posts published via Zernio, "external" for posts imported from platforms."""
         client = _get_client()
         try:
-            response = client.analytics.get_content_decay(
-                platform=platform, profile_id=profile_id, source=source
-            )
+            response = client.analytics.get_content_decay(platform=platform, profile_id=profile_id, source=source)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_posting_frequency(
-        platform: str = "", profile_id: str = "", source: str = "all"
-    ) -> str:
+    def analytics_get_posting_frequency(platform: str = "", profile_id: str = "", source: str = "all") -> str:
         """Get posting frequency vs engagement
 
         Args:
@@ -941,41 +735,31 @@ def register_generated_tools(mcp, _get_client):
             source: Filter by post origin. "late" for posts published via Zernio, "external" for posts imported from platforms."""
         client = _get_client()
         try:
-            response = client.analytics.get_posting_frequency(
-                platform=platform, profile_id=profile_id, source=source
-            )
+            response = client.analytics.get_posting_frequency(platform=platform, profile_id=profile_id, source=source)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_post_timeline(
-        post_id: str, from_date: str = "", to_date: str = ""
-    ) -> str:
+    def analytics_get_post_timeline(post_id: str, from_date: str = "", to_date: str = "") -> str:
         """Get post analytics timeline
 
-           Args:
-               post_id: The post to fetch timeline for. Accepts an ExternalPost ID, a platformPostId, or a Zernio Post ID.
-        (required)
-               from_date: Start of date range (ISO 8601). Defaults to 90 days ago.
-               to_date: End of date range (ISO 8601). Defaults to now."""
+        Args:
+            post_id: The post to fetch timeline for. Accepts an ExternalPost ID, a platformPostId, or a Zernio Post ID.
+     (required)
+            from_date: Start of date range (ISO 8601). Defaults to 90 days ago.
+            to_date: End of date range (ISO 8601). Defaults to now."""
         client = _get_client()
         try:
-            response = client.analytics.get_post_timeline(
-                post_id=post_id, from_date=from_date, to_date=to_date
-            )
+            response = client.analytics.get_post_timeline(post_id=post_id, from_date=from_date, to_date=to_date)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_linked_in_aggregate_analytics(
-        account_id: str,
-        aggregation: str = "TOTAL",
-        start_date: str = "",
-        end_date: str = "",
-        metrics: str = "",
-    ) -> str:
+    def analytics_get_linked_in_aggregate_analytics(account_id: str, aggregation: str = "TOTAL", start_date: str = "", end_date: str = "", metrics: str = "") -> str:
         """Get LinkedIn aggregate stats
 
         Args:
@@ -986,16 +770,11 @@ def register_generated_tools(mcp, _get_client):
             metrics: Comma-separated metrics: IMPRESSION, MEMBERS_REACHED, REACTION, COMMENT, RESHARE. Omit for all."""
         client = _get_client()
         try:
-            response = client.analytics.get_linked_in_aggregate_analytics(
-                account_id=account_id,
-                aggregation=aggregation,
-                start_date=start_date,
-                end_date=end_date,
-                metrics=metrics,
-            )
+            response = client.analytics.get_linked_in_aggregate_analytics(account_id=account_id, aggregation=aggregation, start_date=start_date, end_date=end_date, metrics=metrics)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def analytics_get_linked_in_post_analytics(account_id: str, urn: str) -> str:
@@ -1006,17 +785,14 @@ def register_generated_tools(mcp, _get_client):
             urn: The LinkedIn post URN (required)"""
         client = _get_client()
         try:
-            response = client.analytics.get_linked_in_post_analytics(
-                account_id=account_id, urn=urn
-            )
+            response = client.analytics.get_linked_in_post_analytics(account_id=account_id, urn=urn)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def analytics_get_linked_in_post_reactions(
-        account_id: str, urn: str, limit: int = 25, cursor: str = ""
-    ) -> str:
+    def analytics_get_linked_in_post_reactions(account_id: str, urn: str, limit: int = 25, cursor: str = "") -> str:
         """Get LinkedIn post reactions
 
         Args:
@@ -1026,14 +802,13 @@ def register_generated_tools(mcp, _get_client):
             cursor: Offset-based pagination start index"""
         client = _get_client()
         try:
-            response = client.analytics.get_linked_in_post_reactions(
-                account_id=account_id, urn=urn, limit=limit, cursor=cursor
-            )
+            response = client.analytics.get_linked_in_post_reactions(account_id=account_id, urn=urn, limit=limit, cursor=cursor)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # API_KEYS
+
 
     @mcp.tool()
     def api_keys_list_api_keys() -> str:
@@ -1043,16 +818,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.api_keys.list_api_keys()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def api_keys_create_api_key(
-        name: str,
-        expires_in: int = 0,
-        scope: str = "full",
-        profile_ids: str = "",
-        permission: str = "read-write",
-    ) -> str:
+    def api_keys_create_api_key(name: str, expires_in: int = 0, scope: str = "full", profile_ids: str = "", permission: str = "read-write") -> str:
         """Create key
 
         Args:
@@ -1063,16 +833,11 @@ def register_generated_tools(mcp, _get_client):
             permission: 'read-write' allows all operations (default), 'read' restricts to GET requests only"""
         client = _get_client()
         try:
-            response = client.api_keys.create_api_key(
-                name=name,
-                expiresIn=expires_in,
-                scope=scope,
-                profileIds=profile_ids,
-                permission=permission,
-            )
+            response = client.api_keys.create_api_key(name=name, expires_in=expires_in, scope=scope, profile_ids=profile_ids, permission=permission)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def api_keys_delete_api_key(key_id: str) -> str:
@@ -1085,18 +850,13 @@ def register_generated_tools(mcp, _get_client):
             response = client.api_keys.delete_api_key(key_id=key_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # BROADCASTS
 
+
     @mcp.tool()
-    def broadcasts_list_broadcasts(
-        profile_id: str = "",
-        status: str = "",
-        platform: str = "",
-        limit: int = 50,
-        skip: int = 0,
-    ) -> str:
+    def broadcasts_list_broadcasts(profile_id: str = "", status: str = "", platform: str = "", limit: int = 50, skip: int = 0) -> str:
         """List broadcasts
 
         Args:
@@ -1107,28 +867,14 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.broadcasts.list_broadcasts(
-                profile_id=profile_id,
-                status=status,
-                platform=platform,
-                limit=limit,
-                skip=skip,
-            )
+            response = client.broadcasts.list_broadcasts(profile_id=profile_id, status=status, platform=platform, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def broadcasts_create_broadcast(
-        profile_id: str,
-        account_id: str,
-        platform: str,
-        name: str,
-        description: str = "",
-        message: str = "",
-        template: str = "",
-        segment_filters: str = "",
-    ) -> str:
+    def broadcasts_create_broadcast(profile_id: str, account_id: str, platform: str, name: str, description: str = "", message: str = "", template: str = "", segment_filters: str = "") -> str:
         """Create a broadcast draft
 
         Args:
@@ -1142,19 +888,11 @@ def register_generated_tools(mcp, _get_client):
             segment_filters"""
         client = _get_client()
         try:
-            response = client.broadcasts.create_broadcast(
-                profileId=profile_id,
-                accountId=account_id,
-                platform=platform,
-                name=name,
-                description=description,
-                message=message,
-                template=template,
-                segmentFilters=segment_filters,
-            )
+            response = client.broadcasts.create_broadcast(profile_id=profile_id, account_id=account_id, platform=platform, name=name, description=description, message=message, template=template, segment_filters=segment_filters)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_get_broadcast(broadcast_id: str) -> str:
@@ -1167,7 +905,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.broadcasts.get_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_update_broadcast(broadcast_id: str) -> str:
@@ -1180,7 +919,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.broadcasts.update_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_delete_broadcast(broadcast_id: str) -> str:
@@ -1193,7 +933,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.broadcasts.delete_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_send_broadcast(broadcast_id: str) -> str:
@@ -1206,7 +947,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.broadcasts.send_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_schedule_broadcast(broadcast_id: str, scheduled_at: str) -> str:
@@ -1217,12 +959,11 @@ def register_generated_tools(mcp, _get_client):
             scheduled_at: (required)"""
         client = _get_client()
         try:
-            response = client.broadcasts.schedule_broadcast(
-                broadcast_id=broadcast_id, scheduledAt=scheduled_at
-            )
+            response = client.broadcasts.schedule_broadcast(broadcast_id=broadcast_id, scheduled_at=scheduled_at)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def broadcasts_cancel_broadcast(broadcast_id: str) -> str:
@@ -1235,12 +976,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.broadcasts.cancel_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def broadcasts_list_broadcast_recipients(
-        broadcast_id: str, status: str = "", limit: int = 50, skip: int = 0
-    ) -> str:
+    def broadcasts_list_broadcast_recipients(broadcast_id: str, status: str = "", limit: int = 50, skip: int = 0) -> str:
         """List broadcast recipients
 
         Args:
@@ -1250,20 +990,14 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.broadcasts.list_broadcast_recipients(
-                broadcast_id=broadcast_id, status=status, limit=limit, skip=skip
-            )
+            response = client.broadcasts.list_broadcast_recipients(broadcast_id=broadcast_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def broadcasts_add_broadcast_recipients(
-        broadcast_id: str,
-        contact_ids: str = "",
-        phones: str = "",
-        use_segment: bool = False,
-    ) -> str:
+    def broadcasts_add_broadcast_recipients(broadcast_id: str, contact_ids: str = "", phones: str = "", use_segment: bool = False) -> str:
         """Add recipients to a broadcast
 
         Args:
@@ -1273,17 +1007,13 @@ def register_generated_tools(mcp, _get_client):
             use_segment: Auto-populate from broadcast segment filters"""
         client = _get_client()
         try:
-            response = client.broadcasts.add_broadcast_recipients(
-                broadcast_id=broadcast_id,
-                contactIds=contact_ids,
-                phones=phones,
-                useSegment=use_segment,
-            )
+            response = client.broadcasts.add_broadcast_recipients(broadcast_id=broadcast_id, contact_ids=contact_ids, phones=phones, use_segment=use_segment)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # COMMENT_AUTOMATIONS
+
 
     @mcp.tool()
     def comment_automations_list_comment_automations(profile_id: str = "") -> str:
@@ -1293,26 +1023,14 @@ def register_generated_tools(mcp, _get_client):
             profile_id: Filter by profile. Omit to list across all profiles"""
         client = _get_client()
         try:
-            response = client.comment_automations.list_comment_automations(
-                profile_id=profile_id
-            )
+            response = client.comment_automations.list_comment_automations(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comment_automations_create_comment_automation(
-        profile_id: str,
-        account_id: str,
-        platform_post_id: str,
-        name: str,
-        dm_message: str,
-        post_id: str = "",
-        post_title: str = "",
-        keywords: str = "",
-        match_mode: str = "contains",
-        comment_reply: str = "",
-    ) -> str:
+    def comment_automations_create_comment_automation(profile_id: str, account_id: str, platform_post_id: str, name: str, dm_message: str, post_id: str = "", post_title: str = "", keywords: str = "", match_mode: str = "contains", comment_reply: str = "") -> str:
         """Create a comment-to-DM automation
 
         Args:
@@ -1328,21 +1046,11 @@ def register_generated_tools(mcp, _get_client):
             comment_reply: Optional public reply to the comment"""
         client = _get_client()
         try:
-            response = client.comment_automations.create_comment_automation(
-                profileId=profile_id,
-                accountId=account_id,
-                platformPostId=platform_post_id,
-                postId=post_id,
-                postTitle=post_title,
-                name=name,
-                keywords=keywords,
-                matchMode=match_mode,
-                dmMessage=dm_message,
-                commentReply=comment_reply,
-            )
+            response = client.comment_automations.create_comment_automation(profile_id=profile_id, account_id=account_id, platform_post_id=platform_post_id, post_id=post_id, post_title=post_title, name=name, keywords=keywords, match_mode=match_mode, dm_message=dm_message, comment_reply=comment_reply)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def comment_automations_get_comment_automation(automation_id: str) -> str:
@@ -1352,23 +1060,14 @@ def register_generated_tools(mcp, _get_client):
             automation_id: (required)"""
         client = _get_client()
         try:
-            response = client.comment_automations.get_comment_automation(
-                automation_id=automation_id
-            )
+            response = client.comment_automations.get_comment_automation(automation_id=automation_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comment_automations_update_comment_automation(
-        automation_id: str,
-        name: str = "",
-        keywords: str = "",
-        match_mode: str = "",
-        dm_message: str = "",
-        comment_reply: str = "",
-        is_active: bool = False,
-    ) -> str:
+    def comment_automations_update_comment_automation(automation_id: str, name: str = "", keywords: str = "", match_mode: str = "", dm_message: str = "", comment_reply: str = "", is_active: bool = False) -> str:
         """Update automation settings
 
         Args:
@@ -1381,18 +1080,11 @@ def register_generated_tools(mcp, _get_client):
             is_active"""
         client = _get_client()
         try:
-            response = client.comment_automations.update_comment_automation(
-                automation_id=automation_id,
-                name=name,
-                keywords=keywords,
-                matchMode=match_mode,
-                dmMessage=dm_message,
-                commentReply=comment_reply,
-                isActive=is_active,
-            )
+            response = client.comment_automations.update_comment_automation(automation_id=automation_id, name=name, keywords=keywords, match_mode=match_mode, dm_message=dm_message, comment_reply=comment_reply, is_active=is_active)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def comment_automations_delete_comment_automation(automation_id: str) -> str:
@@ -1402,17 +1094,14 @@ def register_generated_tools(mcp, _get_client):
             automation_id: (required)"""
         client = _get_client()
         try:
-            response = client.comment_automations.delete_comment_automation(
-                automation_id=automation_id
-            )
+            response = client.comment_automations.delete_comment_automation(automation_id=automation_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comment_automations_list_comment_automation_logs(
-        automation_id: str, status: str = "", limit: int = 50, skip: int = 0
-    ) -> str:
+    def comment_automations_list_comment_automation_logs(automation_id: str, status: str = "", limit: int = 50, skip: int = 0) -> str:
         """List trigger logs for an automation
 
         Args:
@@ -1422,27 +1111,16 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.comment_automations.list_comment_automation_logs(
-                automation_id=automation_id, status=status, limit=limit, skip=skip
-            )
+            response = client.comment_automations.list_comment_automation_logs(automation_id=automation_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # COMMENTS
 
+
     @mcp.tool()
-    def comments_list_inbox_comments(
-        profile_id: str = "",
-        platform: str = "",
-        min_comments: int = 0,
-        since: str = "",
-        sort_by: str = "date",
-        sort_order: str = "desc",
-        limit: int = 50,
-        cursor: str = "",
-        account_id: str = "",
-    ) -> str:
+    def comments_list_inbox_comments(profile_id: str = "", platform: str = "", min_comments: int = 0, since: str = "", sort_by: str = "date", sort_order: str = "desc", limit: int = 50, cursor: str = "", account_id: str = "") -> str:
         """List commented posts
 
         Args:
@@ -1457,30 +1135,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: Filter by specific social account ID"""
         client = _get_client()
         try:
-            response = client.comments.list_inbox_comments(
-                profile_id=profile_id,
-                platform=platform,
-                min_comments=min_comments,
-                since=since,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                limit=limit,
-                cursor=cursor,
-                account_id=account_id,
-            )
+            response = client.comments.list_inbox_comments(profile_id=profile_id, platform=platform, min_comments=min_comments, since=since, sort_by=sort_by, sort_order=sort_order, limit=limit, cursor=cursor, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_get_inbox_post_comments(
-        post_id: str,
-        account_id: str,
-        subreddit: str = "",
-        limit: int = 25,
-        cursor: str = "",
-        comment_id: str = "",
-    ) -> str:
+    def comments_get_inbox_post_comments(post_id: str, account_id: str, subreddit: str = "", limit: int = 25, cursor: str = "", comment_id: str = "") -> str:
         """Get post comments
 
         Args:
@@ -1492,28 +1154,14 @@ def register_generated_tools(mcp, _get_client):
             comment_id: (Reddit only) Get replies to a specific comment"""
         client = _get_client()
         try:
-            response = client.comments.get_inbox_post_comments(
-                post_id=post_id,
-                account_id=account_id,
-                subreddit=subreddit,
-                limit=limit,
-                cursor=cursor,
-                comment_id=comment_id,
-            )
+            response = client.comments.get_inbox_post_comments(post_id=post_id, account_id=account_id, subreddit=subreddit, limit=limit, cursor=cursor, comment_id=comment_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_reply_to_inbox_post(
-        post_id: str,
-        account_id: str,
-        message: str,
-        comment_id: str = "",
-        parent_cid: str = "",
-        root_uri: str = "",
-        root_cid: str = "",
-    ) -> str:
+    def comments_reply_to_inbox_post(post_id: str, account_id: str, message: str, comment_id: str = "", parent_cid: str = "", root_uri: str = "", root_cid: str = "") -> str:
         """Reply to comment
 
         Args:
@@ -1526,23 +1174,14 @@ def register_generated_tools(mcp, _get_client):
             root_cid: (Bluesky only) Root post CID"""
         client = _get_client()
         try:
-            response = client.comments.reply_to_inbox_post(
-                post_id=post_id,
-                accountId=account_id,
-                message=message,
-                commentId=comment_id,
-                parentCid=parent_cid,
-                rootUri=root_uri,
-                rootCid=root_cid,
-            )
+            response = client.comments.reply_to_inbox_post(post_id=post_id, account_id=account_id, message=message, comment_id=comment_id, parent_cid=parent_cid, root_uri=root_uri, root_cid=root_cid)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_delete_inbox_comment(
-        post_id: str, account_id: str, comment_id: str
-    ) -> str:
+    def comments_delete_inbox_comment(post_id: str, account_id: str, comment_id: str) -> str:
         """Delete comment
 
         Args:
@@ -1551,17 +1190,14 @@ def register_generated_tools(mcp, _get_client):
             comment_id: (required)"""
         client = _get_client()
         try:
-            response = client.comments.delete_inbox_comment(
-                post_id=post_id, account_id=account_id, comment_id=comment_id
-            )
+            response = client.comments.delete_inbox_comment(post_id=post_id, account_id=account_id, comment_id=comment_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_hide_inbox_comment(
-        post_id: str, comment_id: str, account_id: str
-    ) -> str:
+    def comments_hide_inbox_comment(post_id: str, comment_id: str, account_id: str) -> str:
         """Hide comment
 
         Args:
@@ -1570,17 +1206,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: The social account ID (required)"""
         client = _get_client()
         try:
-            response = client.comments.hide_inbox_comment(
-                post_id=post_id, comment_id=comment_id, accountId=account_id
-            )
+            response = client.comments.hide_inbox_comment(post_id=post_id, comment_id=comment_id, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_unhide_inbox_comment(
-        post_id: str, comment_id: str, account_id: str
-    ) -> str:
+    def comments_unhide_inbox_comment(post_id: str, comment_id: str, account_id: str) -> str:
         """Unhide comment
 
         Args:
@@ -1589,17 +1222,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.comments.unhide_inbox_comment(
-                post_id=post_id, comment_id=comment_id, account_id=account_id
-            )
+            response = client.comments.unhide_inbox_comment(post_id=post_id, comment_id=comment_id, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_like_inbox_comment(
-        post_id: str, comment_id: str, account_id: str, cid: str = ""
-    ) -> str:
+    def comments_like_inbox_comment(post_id: str, comment_id: str, account_id: str, cid: str = "") -> str:
         """Like comment
 
         Args:
@@ -1609,17 +1239,14 @@ def register_generated_tools(mcp, _get_client):
             cid: (Bluesky only) Content identifier for the comment"""
         client = _get_client()
         try:
-            response = client.comments.like_inbox_comment(
-                post_id=post_id, comment_id=comment_id, accountId=account_id, cid=cid
-            )
+            response = client.comments.like_inbox_comment(post_id=post_id, comment_id=comment_id, account_id=account_id, cid=cid)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_unlike_inbox_comment(
-        post_id: str, comment_id: str, account_id: str, like_uri: str = ""
-    ) -> str:
+    def comments_unlike_inbox_comment(post_id: str, comment_id: str, account_id: str, like_uri: str = "") -> str:
         """Unlike comment
 
         Args:
@@ -1629,20 +1256,14 @@ def register_generated_tools(mcp, _get_client):
             like_uri: (Bluesky only) The like URI returned when liking"""
         client = _get_client()
         try:
-            response = client.comments.unlike_inbox_comment(
-                post_id=post_id,
-                comment_id=comment_id,
-                account_id=account_id,
-                like_uri=like_uri,
-            )
+            response = client.comments.unlike_inbox_comment(post_id=post_id, comment_id=comment_id, account_id=account_id, like_uri=like_uri)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def comments_send_private_reply_to_comment(
-        post_id: str, comment_id: str, account_id: str, message: str
-    ) -> str:
+    def comments_send_private_reply_to_comment(post_id: str, comment_id: str, account_id: str, message: str) -> str:
         """Send private reply
 
         Args:
@@ -1652,22 +1273,16 @@ def register_generated_tools(mcp, _get_client):
             message: The message text to send as a private DM (required)"""
         client = _get_client()
         try:
-            response = client.comments.send_private_reply_to_comment(
-                post_id=post_id,
-                comment_id=comment_id,
-                accountId=account_id,
-                message=message,
-            )
+            response = client.comments.send_private_reply_to_comment(post_id=post_id, comment_id=comment_id, account_id=account_id, message=message)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # CONNECT
 
+
     @mcp.tool()
-    def connect_get_connect_url(
-        platform: str, profile_id: str, redirect_url: str = "", headless: bool = False
-    ) -> str:
+    def connect_get_connect_url(platform: str, profile_id: str, redirect_url: str = "", headless: bool = False) -> str:
         """Get OAuth connect URL
 
         Args:
@@ -1677,20 +1292,14 @@ def register_generated_tools(mcp, _get_client):
             headless: When true, the user is redirected to your redirect_url with raw OAuth data (code, state) instead of Zernio's default account selection UI. Use this to build a custom connect experience."""
         client = _get_client()
         try:
-            response = client.connect.get_connect_url(
-                platform=platform,
-                profile_id=profile_id,
-                redirect_url=redirect_url,
-                headless=headless,
-            )
+            response = client.connect.get_connect_url(platform=platform, profile_id=profile_id, redirect_url=redirect_url, headless=headless)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_handle_o_auth_callback(
-        platform: str, code: str, state: str, profile_id: str
-    ) -> str:
+    def connect_handle_o_auth_callback(platform: str, code: str, state: str, profile_id: str) -> str:
         """Complete OAuth callback
 
         Args:
@@ -1700,12 +1309,11 @@ def register_generated_tools(mcp, _get_client):
             profile_id: (required)"""
         client = _get_client()
         try:
-            response = client.connect.handle_o_auth_callback(
-                platform=platform, code=code, state=state, profileId=profile_id
-            )
+            response = client.connect.handle_o_auth_callback(platform=platform, code=code, state=state, profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_list_facebook_pages(profile_id: str, temp_token: str) -> str:
@@ -1716,21 +1324,14 @@ def register_generated_tools(mcp, _get_client):
             temp_token: Temporary Facebook access token from the OAuth callback redirect (required)"""
         client = _get_client()
         try:
-            response = client.connect.list_facebook_pages(
-                profile_id=profile_id, temp_token=temp_token
-            )
+            response = client.connect.list_facebook_pages(profile_id=profile_id, temp_token=temp_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_select_facebook_page(
-        profile_id: str,
-        page_id: str,
-        temp_token: str,
-        user_profile: str = "",
-        redirect_url: str = "",
-    ) -> str:
+    def connect_select_facebook_page(profile_id: str, page_id: str, temp_token: str, user_profile: str = "", redirect_url: str = "") -> str:
         """Select Facebook page
 
         Args:
@@ -1741,16 +1342,11 @@ def register_generated_tools(mcp, _get_client):
             redirect_url: Optional custom redirect URL to return to after selection"""
         client = _get_client()
         try:
-            response = client.connect.select_facebook_page(
-                profileId=profile_id,
-                pageId=page_id,
-                tempToken=temp_token,
-                userProfile=user_profile,
-                redirect_url=redirect_url,
-            )
+            response = client.connect.select_facebook_page(profile_id=profile_id, page_id=page_id, temp_token=temp_token, user_profile=user_profile, redirect_url=redirect_url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_list_google_business_locations(profile_id: str, temp_token: str) -> str:
@@ -1761,21 +1357,14 @@ def register_generated_tools(mcp, _get_client):
             temp_token: Temporary Google access token from the OAuth callback redirect (required)"""
         client = _get_client()
         try:
-            response = client.connect.list_google_business_locations(
-                profile_id=profile_id, temp_token=temp_token
-            )
+            response = client.connect.list_google_business_locations(profile_id=profile_id, temp_token=temp_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_select_google_business_location(
-        profile_id: str,
-        location_id: str,
-        temp_token: str,
-        user_profile: str = "",
-        redirect_url: str = "",
-    ) -> str:
+    def connect_select_google_business_location(profile_id: str, location_id: str, temp_token: str, user_profile: str = "", redirect_url: str = "") -> str:
         """Select GBP location
 
         Args:
@@ -1786,16 +1375,11 @@ def register_generated_tools(mcp, _get_client):
             redirect_url: Optional custom redirect URL to return to after selection"""
         client = _get_client()
         try:
-            response = client.connect.select_google_business_location(
-                profileId=profile_id,
-                locationId=location_id,
-                tempToken=temp_token,
-                userProfile=user_profile,
-                redirect_url=redirect_url,
-            )
+            response = client.connect.select_google_business_location(profile_id=profile_id, location_id=location_id, temp_token=temp_token, user_profile=user_profile, redirect_url=redirect_url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_pending_o_auth_data(token: str) -> str:
@@ -1808,7 +1392,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_pending_o_auth_data(token=token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_list_linked_in_organizations(temp_token: str, org_ids: str) -> str:
@@ -1819,22 +1404,14 @@ def register_generated_tools(mcp, _get_client):
             org_ids: Comma-separated list of organization IDs to fetch details for (max 100) (required)"""
         client = _get_client()
         try:
-            response = client.connect.list_linked_in_organizations(
-                temp_token=temp_token, org_ids=org_ids
-            )
+            response = client.connect.list_linked_in_organizations(temp_token=temp_token, org_ids=org_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_select_linked_in_organization(
-        profile_id: str,
-        temp_token: str,
-        user_profile: str,
-        account_type: str,
-        selected_organization: str = "",
-        redirect_url: str = "",
-    ) -> str:
+    def connect_select_linked_in_organization(profile_id: str, temp_token: str, user_profile: str, account_type: str, selected_organization: str = "", redirect_url: str = "") -> str:
         """Select LinkedIn org
 
         Args:
@@ -1846,22 +1423,14 @@ def register_generated_tools(mcp, _get_client):
             redirect_url"""
         client = _get_client()
         try:
-            response = client.connect.select_linked_in_organization(
-                profileId=profile_id,
-                tempToken=temp_token,
-                userProfile=user_profile,
-                accountType=account_type,
-                selectedOrganization=selected_organization,
-                redirect_url=redirect_url,
-            )
+            response = client.connect.select_linked_in_organization(profile_id=profile_id, temp_token=temp_token, user_profile=user_profile, account_type=account_type, selected_organization=selected_organization, redirect_url=redirect_url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_list_pinterest_boards_for_selection(
-        profile_id: str, temp_token: str
-    ) -> str:
+    def connect_list_pinterest_boards_for_selection(profile_id: str, temp_token: str) -> str:
         """List Pinterest boards
 
         Args:
@@ -1869,24 +1438,14 @@ def register_generated_tools(mcp, _get_client):
             temp_token: Temporary Pinterest access token from the OAuth callback redirect (required)"""
         client = _get_client()
         try:
-            response = client.connect.list_pinterest_boards_for_selection(
-                profile_id=profile_id, temp_token=temp_token
-            )
+            response = client.connect.list_pinterest_boards_for_selection(profile_id=profile_id, temp_token=temp_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_select_pinterest_board(
-        profile_id: str,
-        board_id: str,
-        temp_token: str,
-        board_name: str = "",
-        user_profile: str = "",
-        refresh_token: str = "",
-        expires_in: int = 0,
-        redirect_url: str = "",
-    ) -> str:
+    def connect_select_pinterest_board(profile_id: str, board_id: str, temp_token: str, board_name: str = "", user_profile: str = "", refresh_token: str = "", expires_in: int = 0, redirect_url: str = "") -> str:
         """Select Pinterest board
 
         Args:
@@ -1900,19 +1459,11 @@ def register_generated_tools(mcp, _get_client):
             redirect_url: Custom redirect URL after connection completes"""
         client = _get_client()
         try:
-            response = client.connect.select_pinterest_board(
-                profileId=profile_id,
-                boardId=board_id,
-                boardName=board_name,
-                tempToken=temp_token,
-                userProfile=user_profile,
-                refreshToken=refresh_token,
-                expiresIn=expires_in,
-                redirect_url=redirect_url,
-            )
+            response = client.connect.select_pinterest_board(profile_id=profile_id, board_id=board_id, board_name=board_name, temp_token=temp_token, user_profile=user_profile, refresh_token=refresh_token, expires_in=expires_in, redirect_url=redirect_url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_list_snapchat_profiles(profile_id: str, temp_token: str) -> str:
@@ -1923,23 +1474,14 @@ def register_generated_tools(mcp, _get_client):
             temp_token: Temporary Snapchat access token from the OAuth callback redirect (required)"""
         client = _get_client()
         try:
-            response = client.connect.list_snapchat_profiles(
-                profile_id=profile_id, temp_token=temp_token
-            )
+            response = client.connect.list_snapchat_profiles(profile_id=profile_id, temp_token=temp_token)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_select_snapchat_profile(
-        profile_id: str,
-        selected_public_profile: str,
-        temp_token: str,
-        user_profile: str,
-        refresh_token: str = "",
-        expires_in: int = 0,
-        redirect_url: str = "",
-    ) -> str:
+    def connect_select_snapchat_profile(profile_id: str, selected_public_profile: str, temp_token: str, user_profile: str, refresh_token: str = "", expires_in: int = 0, redirect_url: str = "") -> str:
         """Select Snapchat profile
 
         Args:
@@ -1952,23 +1494,14 @@ def register_generated_tools(mcp, _get_client):
             redirect_url: Custom redirect URL after connection completes"""
         client = _get_client()
         try:
-            response = client.connect.select_snapchat_profile(
-                profileId=profile_id,
-                selectedPublicProfile=selected_public_profile,
-                tempToken=temp_token,
-                userProfile=user_profile,
-                refreshToken=refresh_token,
-                expiresIn=expires_in,
-                redirect_url=redirect_url,
-            )
+            response = client.connect.select_snapchat_profile(profile_id=profile_id, selected_public_profile=selected_public_profile, temp_token=temp_token, user_profile=user_profile, refresh_token=refresh_token, expires_in=expires_in, redirect_url=redirect_url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_bluesky_credentials(
-        identifier: str, app_password: str, state: str, redirect_uri: str = ""
-    ) -> str:
+    def connect_bluesky_credentials(identifier: str, app_password: str, state: str, redirect_uri: str = "") -> str:
         """Connect Bluesky account
 
         Args:
@@ -1978,20 +1511,14 @@ def register_generated_tools(mcp, _get_client):
             redirect_uri: Optional URL to redirect to after successful connection"""
         client = _get_client()
         try:
-            response = client.connect.connect_bluesky_credentials(
-                identifier=identifier,
-                appPassword=app_password,
-                state=state,
-                redirectUri=redirect_uri,
-            )
+            response = client.connect.connect_bluesky_credentials(identifier=identifier, app_password=app_password, state=state, redirect_uri=redirect_uri)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_whats_app_credentials(
-        profile_id: str, access_token: str, waba_id: str, phone_number_id: str
-    ) -> str:
+    def connect_whats_app_credentials(profile_id: str, access_token: str, waba_id: str, phone_number_id: str) -> str:
         """Connect WhatsApp via credentials
 
         Args:
@@ -2001,15 +1528,11 @@ def register_generated_tools(mcp, _get_client):
             phone_number_id: Phone Number ID from Meta WhatsApp Manager (required)"""
         client = _get_client()
         try:
-            response = client.connect.connect_whats_app_credentials(
-                profileId=profile_id,
-                accessToken=access_token,
-                wabaId=waba_id,
-                phoneNumberId=phone_number_id,
-            )
+            response = client.connect.connect_whats_app_credentials(profile_id=profile_id, access_token=access_token, waba_id=waba_id, phone_number_id=phone_number_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_telegram_connect_status(profile_id: str) -> str:
@@ -2022,7 +1545,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_telegram_connect_status(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_initiate_telegram_connect(chat_id: str, profile_id: str) -> str:
@@ -2033,12 +1557,11 @@ def register_generated_tools(mcp, _get_client):
             profile_id: The profile ID to connect the account to (required)"""
         client = _get_client()
         try:
-            response = client.connect.initiate_telegram_connect(
-                chatId=chat_id, profileId=profile_id
-            )
+            response = client.connect.initiate_telegram_connect(chat_id=chat_id, profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_complete_telegram_connect(code: str) -> str:
@@ -2051,7 +1574,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.complete_telegram_connect(code=code)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_facebook_pages(account_id: str) -> str:
@@ -2064,7 +1588,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_facebook_pages(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_update_facebook_page(account_id: str, selected_page_id: str) -> str:
@@ -2075,12 +1600,11 @@ def register_generated_tools(mcp, _get_client):
             selected_page_id: (required)"""
         client = _get_client()
         try:
-            response = client.connect.update_facebook_page(
-                account_id=account_id, selectedPageId=selected_page_id
-            )
+            response = client.connect.update_facebook_page(account_id=account_id, selected_page_id=selected_page_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_linked_in_organizations(account_id: str) -> str:
@@ -2093,12 +1617,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_linked_in_organizations(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_update_linked_in_organization(
-        account_id: str, account_type: str, selected_organization: str = ""
-    ) -> str:
+    def connect_update_linked_in_organization(account_id: str, account_type: str, selected_organization: str = "") -> str:
         """Switch LinkedIn account type
 
         Args:
@@ -2107,14 +1630,11 @@ def register_generated_tools(mcp, _get_client):
             selected_organization"""
         client = _get_client()
         try:
-            response = client.connect.update_linked_in_organization(
-                account_id=account_id,
-                accountType=account_type,
-                selectedOrganization=selected_organization,
-            )
+            response = client.connect.update_linked_in_organization(account_id=account_id, account_type=account_type, selected_organization=selected_organization)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_pinterest_boards(account_id: str) -> str:
@@ -2127,12 +1647,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_pinterest_boards(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_update_pinterest_boards(
-        account_id: str, default_board_id: str, default_board_name: str = ""
-    ) -> str:
+    def connect_update_pinterest_boards(account_id: str, default_board_id: str, default_board_name: str = "") -> str:
         """Set default Pinterest board
 
         Args:
@@ -2141,14 +1660,11 @@ def register_generated_tools(mcp, _get_client):
             default_board_name"""
         client = _get_client()
         try:
-            response = client.connect.update_pinterest_boards(
-                account_id=account_id,
-                defaultBoardId=default_board_id,
-                defaultBoardName=default_board_name,
-            )
+            response = client.connect.update_pinterest_boards(account_id=account_id, default_board_id=default_board_id, default_board_name=default_board_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_gmb_locations(account_id: str) -> str:
@@ -2161,7 +1677,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_gmb_locations(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_update_gmb_location(account_id: str, selected_location_id: str) -> str:
@@ -2172,12 +1689,11 @@ def register_generated_tools(mcp, _get_client):
             selected_location_id: (required)"""
         client = _get_client()
         try:
-            response = client.connect.update_gmb_location(
-                account_id=account_id, selectedLocationId=selected_location_id
-            )
+            response = client.connect.update_gmb_location(account_id=account_id, selected_location_id=selected_location_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_reddit_subreddits(account_id: str) -> str:
@@ -2190,12 +1706,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.connect.get_reddit_subreddits(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def connect_update_reddit_subreddits(
-        account_id: str, default_subreddit: str
-    ) -> str:
+    def connect_update_reddit_subreddits(account_id: str, default_subreddit: str) -> str:
         """Set default subreddit
 
         Args:
@@ -2203,12 +1718,11 @@ def register_generated_tools(mcp, _get_client):
             default_subreddit: (required)"""
         client = _get_client()
         try:
-            response = client.connect.update_reddit_subreddits(
-                account_id=account_id, defaultSubreddit=default_subreddit
-            )
+            response = client.connect.update_reddit_subreddits(account_id=account_id, default_subreddit=default_subreddit)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def connect_get_reddit_flairs(account_id: str, subreddit: str) -> str:
@@ -2219,25 +1733,16 @@ def register_generated_tools(mcp, _get_client):
             subreddit: Subreddit name (without "r/" prefix) to fetch flairs for (required)"""
         client = _get_client()
         try:
-            response = client.connect.get_reddit_flairs(
-                account_id=account_id, subreddit=subreddit
-            )
+            response = client.connect.get_reddit_flairs(account_id=account_id, subreddit=subreddit)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # CONTACTS
 
+
     @mcp.tool()
-    def contacts_list_contacts(
-        profile_id: str = "",
-        search: str = "",
-        tag: str = "",
-        platform: str = "",
-        is_subscribed: str = "",
-        limit: int = 50,
-        skip: int = 0,
-    ) -> str:
+    def contacts_list_contacts(profile_id: str = "", search: str = "", tag: str = "", platform: str = "", is_subscribed: str = "", limit: int = 50, skip: int = 0) -> str:
         """List contacts
 
         Args:
@@ -2250,33 +1755,14 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.contacts.list_contacts(
-                profile_id=profile_id,
-                search=search,
-                tag=tag,
-                platform=platform,
-                is_subscribed=is_subscribed,
-                limit=limit,
-                skip=skip,
-            )
+            response = client.contacts.list_contacts(profile_id=profile_id, search=search, tag=tag, platform=platform, is_subscribed=is_subscribed, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def contacts_create_contact(
-        profile_id: str,
-        name: str,
-        email: str = "",
-        company: str = "",
-        tags: str = "",
-        is_subscribed: bool = True,
-        notes: str = "",
-        account_id: str = "",
-        platform: str = "",
-        platform_identifier: str = "",
-        display_identifier: str = "",
-    ) -> str:
+    def contacts_create_contact(profile_id: str, name: str, email: str = "", company: str = "", tags: str = "", is_subscribed: bool = True, notes: str = "", account_id: str = "", platform: str = "", platform_identifier: str = "", display_identifier: str = "") -> str:
         """Create a contact
 
         Args:
@@ -2293,22 +1779,11 @@ def register_generated_tools(mcp, _get_client):
             display_identifier"""
         client = _get_client()
         try:
-            response = client.contacts.create_contact(
-                profileId=profile_id,
-                name=name,
-                email=email,
-                company=company,
-                tags=tags,
-                isSubscribed=is_subscribed,
-                notes=notes,
-                accountId=account_id,
-                platform=platform,
-                platformIdentifier=platform_identifier,
-                displayIdentifier=display_identifier,
-            )
+            response = client.contacts.create_contact(profile_id=profile_id, name=name, email=email, company=company, tags=tags, is_subscribed=is_subscribed, notes=notes, account_id=account_id, platform=platform, platform_identifier=platform_identifier, display_identifier=display_identifier)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def contacts_get_contact(contact_id: str) -> str:
@@ -2321,20 +1796,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.contacts.get_contact(contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def contacts_update_contact(
-        contact_id: str,
-        name: str = "",
-        email: str = "",
-        company: str = "",
-        avatar_url: str = "",
-        tags: str = "",
-        is_subscribed: bool = False,
-        is_blocked: bool = False,
-        notes: str = "",
-    ) -> str:
+    def contacts_update_contact(contact_id: str, name: str = "", email: str = "", company: str = "", avatar_url: str = "", tags: str = "", is_subscribed: bool = False, is_blocked: bool = False, notes: str = "") -> str:
         """Update a contact
 
         Args:
@@ -2349,20 +1815,11 @@ def register_generated_tools(mcp, _get_client):
             notes"""
         client = _get_client()
         try:
-            response = client.contacts.update_contact(
-                contact_id=contact_id,
-                name=name,
-                email=email,
-                company=company,
-                avatarUrl=avatar_url,
-                tags=tags,
-                isSubscribed=is_subscribed,
-                isBlocked=is_blocked,
-                notes=notes,
-            )
+            response = client.contacts.update_contact(contact_id=contact_id, name=name, email=email, company=company, avatar_url=avatar_url, tags=tags, is_subscribed=is_subscribed, is_blocked=is_blocked, notes=notes)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def contacts_delete_contact(contact_id: str) -> str:
@@ -2375,7 +1832,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.contacts.delete_contact(contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def contacts_get_contact_channels(contact_id: str) -> str:
@@ -2388,12 +1846,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.contacts.get_contact_channels(contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def contacts_bulk_create_contacts(
-        profile_id: str, account_id: str, platform: str, contacts: str
-    ) -> str:
+    def contacts_bulk_create_contacts(profile_id: str, account_id: str, platform: str, contacts: str) -> str:
         """Bulk create contacts
 
         Args:
@@ -2403,22 +1860,16 @@ def register_generated_tools(mcp, _get_client):
             contacts: (required)"""
         client = _get_client()
         try:
-            response = client.contacts.bulk_create_contacts(
-                profileId=profile_id,
-                accountId=account_id,
-                platform=platform,
-                contacts=contacts,
-            )
+            response = client.contacts.bulk_create_contacts(profile_id=profile_id, account_id=account_id, platform=platform, contacts=contacts)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # CUSTOM_FIELDS
 
+
     @mcp.tool()
-    def custom_fields_set_contact_field_value(
-        contact_id: str, slug: str, value: str
-    ) -> str:
+    def custom_fields_set_contact_field_value(contact_id: str, slug: str, value: str) -> str:
         """Set a custom field value
 
         Args:
@@ -2427,12 +1878,11 @@ def register_generated_tools(mcp, _get_client):
             value: Field value (type depends on field definition) (required)"""
         client = _get_client()
         try:
-            response = client.custom_fields.set_contact_field_value(
-                contact_id=contact_id, slug=slug, value=value
-            )
+            response = client.custom_fields.set_contact_field_value(contact_id=contact_id, slug=slug, value=value)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def custom_fields_clear_contact_field_value(contact_id: str, slug: str) -> str:
@@ -2443,12 +1893,11 @@ def register_generated_tools(mcp, _get_client):
             slug: (required)"""
         client = _get_client()
         try:
-            response = client.custom_fields.clear_contact_field_value(
-                contact_id=contact_id, slug=slug
-            )
+            response = client.custom_fields.clear_contact_field_value(contact_id=contact_id, slug=slug)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def custom_fields_list_custom_fields(profile_id: str = "") -> str:
@@ -2461,12 +1910,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.custom_fields.list_custom_fields(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def custom_fields_create_custom_field(
-        profile_id: str, name: str, type: str, slug: str = "", options: str = ""
-    ) -> str:
+    def custom_fields_create_custom_field(profile_id: str, name: str, type: str, slug: str = "", options: str = "") -> str:
         """Create a custom field definition
 
         Args:
@@ -2477,17 +1925,14 @@ def register_generated_tools(mcp, _get_client):
             options: Required for select type"""
         client = _get_client()
         try:
-            response = client.custom_fields.create_custom_field(
-                profileId=profile_id, name=name, slug=slug, type=type, options=options
-            )
+            response = client.custom_fields.create_custom_field(profile_id=profile_id, name=name, slug=slug, type=type, options=options)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def custom_fields_update_custom_field(
-        field_id: str, name: str = "", options: str = ""
-    ) -> str:
+    def custom_fields_update_custom_field(field_id: str, name: str = "", options: str = "") -> str:
         """Update a custom field definition
 
         Args:
@@ -2496,12 +1941,11 @@ def register_generated_tools(mcp, _get_client):
             options"""
         client = _get_client()
         try:
-            response = client.custom_fields.update_custom_field(
-                field_id=field_id, name=name, options=options
-            )
+            response = client.custom_fields.update_custom_field(field_id=field_id, name=name, options=options)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def custom_fields_delete_custom_field(field_id: str) -> str:
@@ -2514,9 +1958,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.custom_fields.delete_custom_field(field_id=field_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # INVITES
+
 
     @mcp.tool()
     def invites_create_invite_token(scope: str, profile_ids: str = "") -> str:
@@ -2527,25 +1972,16 @@ def register_generated_tools(mcp, _get_client):
             profile_ids: Required if scope is 'profiles'. Array of profile IDs to grant access to."""
         client = _get_client()
         try:
-            response = client.invites.create_invite_token(
-                scope=scope, profileIds=profile_ids
-            )
+            response = client.invites.create_invite_token(scope=scope, profile_ids=profile_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # LOGS
 
+
     @mcp.tool()
-    def logs_list_posts_logs(
-        status: str = "",
-        platform: str = "",
-        action: str = "",
-        days: int = 7,
-        limit: int = 50,
-        skip: int = 0,
-        search: str = "",
-    ) -> str:
+    def logs_list_posts_logs(status: str = "", platform: str = "", action: str = "", days: int = 7, limit: int = 50, skip: int = 0, search: str = "") -> str:
         """List publishing logs
 
         Args:
@@ -2558,28 +1994,14 @@ def register_generated_tools(mcp, _get_client):
             search: Search through log entries by text content."""
         client = _get_client()
         try:
-            response = client.logs.list_posts_logs(
-                status=status,
-                platform=platform,
-                action=action,
-                days=days,
-                limit=limit,
-                skip=skip,
-                search=search,
-            )
+            response = client.logs.list_posts_logs(status=status, platform=platform, action=action, days=days, limit=limit, skip=skip, search=search)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def logs_list_connection_logs(
-        platform: str = "",
-        event_type: str = "",
-        status: str = "",
-        days: int = 7,
-        limit: int = 50,
-        skip: int = 0,
-    ) -> str:
+    def logs_list_connection_logs(platform: str = "", event_type: str = "", status: str = "", days: int = 7, limit: int = 50, skip: int = 0) -> str:
         """List connection logs
 
         Args:
@@ -2591,17 +2013,11 @@ def register_generated_tools(mcp, _get_client):
             skip: Number of logs to skip (for pagination)"""
         client = _get_client()
         try:
-            response = client.logs.list_connection_logs(
-                platform=platform,
-                event_type=event_type,
-                status=status,
-                days=days,
-                limit=limit,
-                skip=skip,
-            )
+            response = client.logs.list_connection_logs(platform=platform, event_type=event_type, status=status, days=days, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def logs_get_post_logs(post_id: str, limit: int = 50) -> str:
@@ -2615,14 +2031,13 @@ def register_generated_tools(mcp, _get_client):
             response = client.logs.get_post_logs(post_id=post_id, limit=limit)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # MEDIA
 
+
     @mcp.tool()
-    def media_get_media_presigned_url(
-        filename: str, content_type: str, size: int = 0
-    ) -> str:
+    def media_get_media_presigned_url(filename: str, content_type: str, size: int = 0) -> str:
         """Get presigned upload URL
 
         Args:
@@ -2631,25 +2046,16 @@ def register_generated_tools(mcp, _get_client):
             size: Optional file size in bytes for pre-validation (max 5GB)"""
         client = _get_client()
         try:
-            response = client.media.get_media_presigned_url(
-                filename=filename, contentType=content_type, size=size
-            )
+            response = client.media.get_media_presigned_url(filename=filename, content_type=content_type, size=size)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # MESSAGES
 
+
     @mcp.tool()
-    def messages_list_inbox_conversations(
-        profile_id: str = "",
-        platform: str = "",
-        status: str = "",
-        sort_order: str = "desc",
-        limit: int = 50,
-        cursor: str = "",
-        account_id: str = "",
-    ) -> str:
+    def messages_list_inbox_conversations(profile_id: str = "", platform: str = "", status: str = "", sort_order: str = "desc", limit: int = 50, cursor: str = "", account_id: str = "") -> str:
         """List conversations
 
         Args:
@@ -2662,18 +2068,11 @@ def register_generated_tools(mcp, _get_client):
             account_id: Filter by specific social account ID"""
         client = _get_client()
         try:
-            response = client.messages.list_inbox_conversations(
-                profile_id=profile_id,
-                platform=platform,
-                status=status,
-                sort_order=sort_order,
-                limit=limit,
-                cursor=cursor,
-                account_id=account_id,
-            )
+            response = client.messages.list_inbox_conversations(profile_id=profile_id, platform=platform, status=status, sort_order=sort_order, limit=limit, cursor=cursor, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def messages_get_inbox_conversation(conversation_id: str, account_id: str) -> str:
@@ -2684,17 +2083,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: The social account ID (required)"""
         client = _get_client()
         try:
-            response = client.messages.get_inbox_conversation(
-                conversation_id=conversation_id, account_id=account_id
-            )
+            response = client.messages.get_inbox_conversation(conversation_id=conversation_id, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def messages_update_inbox_conversation(
-        conversation_id: str, account_id: str, status: str
-    ) -> str:
+    def messages_update_inbox_conversation(conversation_id: str, account_id: str, status: str) -> str:
         """Update conversation status
 
         Args:
@@ -2703,17 +2099,14 @@ def register_generated_tools(mcp, _get_client):
             status: (required)"""
         client = _get_client()
         try:
-            response = client.messages.update_inbox_conversation(
-                conversation_id=conversation_id, accountId=account_id, status=status
-            )
+            response = client.messages.update_inbox_conversation(conversation_id=conversation_id, account_id=account_id, status=status)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def messages_get_inbox_conversation_messages(
-        conversation_id: str, account_id: str
-    ) -> str:
+    def messages_get_inbox_conversation_messages(conversation_id: str, account_id: str) -> str:
         """List messages
 
         Args:
@@ -2721,28 +2114,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: Social account ID (required)"""
         client = _get_client()
         try:
-            response = client.messages.get_inbox_conversation_messages(
-                conversation_id=conversation_id, account_id=account_id
-            )
+            response = client.messages.get_inbox_conversation_messages(conversation_id=conversation_id, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def messages_send_inbox_message(
-        conversation_id: str,
-        account_id: str,
-        message: str = "",
-        attachment_url: str = "",
-        attachment_type: str = "",
-        quick_replies: str = "",
-        buttons: str = "",
-        template: str = "",
-        reply_markup: str = "",
-        messaging_type: str = "",
-        message_tag: str = "",
-        reply_to: str = "",
-    ) -> str:
+    def messages_send_inbox_message(conversation_id: str, account_id: str, message: str = "", attachment_url: str = "", attachment_type: str = "", quick_replies: str = "", buttons: str = "", template: str = "", reply_markup: str = "", messaging_type: str = "", message_tag: str = "", reply_to: str = "") -> str:
         """Send message
 
         Args:
@@ -2760,32 +2139,14 @@ def register_generated_tools(mcp, _get_client):
             reply_to: Platform message ID to reply to (Telegram only)."""
         client = _get_client()
         try:
-            response = client.messages.send_inbox_message(
-                conversation_id=conversation_id,
-                accountId=account_id,
-                message=message,
-                attachmentUrl=attachment_url,
-                attachmentType=attachment_type,
-                quickReplies=quick_replies,
-                buttons=buttons,
-                template=template,
-                replyMarkup=reply_markup,
-                messagingType=messaging_type,
-                messageTag=message_tag,
-                replyTo=reply_to,
-            )
+            response = client.messages.send_inbox_message(conversation_id=conversation_id, account_id=account_id, message=message, attachment_url=attachment_url, attachment_type=attachment_type, quick_replies=quick_replies, buttons=buttons, template=template, reply_markup=reply_markup, messaging_type=messaging_type, message_tag=message_tag, reply_to=reply_to)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def messages_edit_inbox_message(
-        conversation_id: str,
-        message_id: str,
-        account_id: str,
-        text: str = "",
-        reply_markup: str = "",
-    ) -> str:
+    def messages_edit_inbox_message(conversation_id: str, message_id: str, account_id: str, text: str = "", reply_markup: str = "") -> str:
         """Edit message
 
         Args:
@@ -2796,33 +2157,16 @@ def register_generated_tools(mcp, _get_client):
             reply_markup: New inline keyboard markup"""
         client = _get_client()
         try:
-            response = client.messages.edit_inbox_message(
-                conversation_id=conversation_id,
-                message_id=message_id,
-                accountId=account_id,
-                text=text,
-                replyMarkup=reply_markup,
-            )
+            response = client.messages.edit_inbox_message(conversation_id=conversation_id, message_id=message_id, account_id=account_id, text=text, reply_markup=reply_markup)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # POSTS
 
+
     @mcp.tool()
-    def posts_list_posts(
-        page: int = 1,
-        limit: int = 10,
-        status: str = "",
-        platform: str = "",
-        profile_id: str = "",
-        created_by: str = "",
-        date_from: str = "",
-        date_to: str = "",
-        include_hidden: bool = False,
-        search: str = "",
-        sort_by: str = "scheduled-desc",
-    ) -> str:
+    def posts_list_posts(page: int = 1, limit: int = 10, status: str = "", platform: str = "", profile_id: str = "", created_by: str = "", date_from: str = "", date_to: str = "", include_hidden: bool = False, search: str = "", sort_by: str = "scheduled-desc") -> str:
         """List posts
 
         Args:
@@ -2839,22 +2183,11 @@ def register_generated_tools(mcp, _get_client):
             sort_by: Sort order for results."""
         client = _get_client()
         try:
-            response = client.posts.list_posts(
-                page=page,
-                limit=limit,
-                status=status,
-                platform=platform,
-                profile_id=profile_id,
-                created_by=created_by,
-                date_from=date_from,
-                date_to=date_to,
-                include_hidden=include_hidden,
-                search=search,
-                sort_by=sort_by,
-            )
+            response = client.posts.list_posts(page=page, limit=limit, status=status, platform=platform, profile_id=profile_id, created_by=created_by, date_from=date_from, date_to=date_to, include_hidden=include_hidden, search=search, sort_by=sort_by)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def posts_get_post(post_id: str) -> str:
@@ -2867,16 +2200,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.posts.get_post(post_id=post_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def posts_update_post(
-        post_id: str,
-        content: str = "",
-        scheduled_for: str = "",
-        tiktok_settings: str = "",
-        recycling: str = "",
-    ) -> str:
+    def posts_update_post(post_id: str, content: str = "", scheduled_for: str = "", tiktok_settings: str = "", recycling: str = "") -> str:
         """Update post
 
         Args:
@@ -2887,16 +2215,11 @@ def register_generated_tools(mcp, _get_client):
             recycling"""
         client = _get_client()
         try:
-            response = client.posts.update_post(
-                post_id=post_id,
-                content=content,
-                scheduledFor=scheduled_for,
-                tiktokSettings=tiktok_settings,
-                recycling=recycling,
-            )
+            response = client.posts.update_post(post_id=post_id, content=content, scheduled_for=scheduled_for, tiktok_settings=tiktok_settings, recycling=recycling)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def posts_delete_post(post_id: str) -> str:
@@ -2909,7 +2232,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.posts.delete_post(post_id=post_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def posts_bulk_upload_posts(dry_run: bool = False) -> str:
@@ -2922,7 +2246,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.posts.bulk_upload_posts(dry_run=dry_run)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def posts_unpublish_post(post_id: str, platform: str) -> str:
@@ -2936,9 +2261,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.posts.unpublish_post(post_id=post_id, platform=platform)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # PROFILES
+
 
     @mcp.tool()
     def profiles_list_profiles(include_over_limit: bool = False) -> str:
@@ -2948,17 +2274,14 @@ def register_generated_tools(mcp, _get_client):
             include_over_limit: When true, includes over-limit profiles (marked with isOverLimit: true)."""
         client = _get_client()
         try:
-            response = client.profiles.list_profiles(
-                include_over_limit=include_over_limit
-            )
+            response = client.profiles.list_profiles(include_over_limit=include_over_limit)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def profiles_create_profile(
-        name: str, description: str = "", color: str = ""
-    ) -> str:
+    def profiles_create_profile(name: str, description: str = "", color: str = "") -> str:
         """Create profile
 
         Args:
@@ -2967,12 +2290,11 @@ def register_generated_tools(mcp, _get_client):
             color"""
         client = _get_client()
         try:
-            response = client.profiles.create_profile(
-                name=name, description=description, color=color
-            )
+            response = client.profiles.create_profile(name=name, description=description, color=color)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def profiles_get_profile(profile_id: str) -> str:
@@ -2985,16 +2307,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.profiles.get_profile(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def profiles_update_profile(
-        profile_id: str,
-        name: str = "",
-        description: str = "",
-        color: str = "",
-        is_default: bool = False,
-    ) -> str:
+    def profiles_update_profile(profile_id: str, name: str = "", description: str = "", color: str = "", is_default: bool = False) -> str:
         """Update profile
 
         Args:
@@ -3005,16 +2322,11 @@ def register_generated_tools(mcp, _get_client):
             is_default"""
         client = _get_client()
         try:
-            response = client.profiles.update_profile(
-                profile_id=profile_id,
-                name=name,
-                description=description,
-                color=color,
-                isDefault=is_default,
-            )
+            response = client.profiles.update_profile(profile_id=profile_id, name=name, description=description, color=color, is_default=is_default)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def profiles_delete_profile(profile_id: str) -> str:
@@ -3027,14 +2339,13 @@ def register_generated_tools(mcp, _get_client):
             response = client.profiles.delete_profile(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # QUEUE
 
+
     @mcp.tool()
-    def queue_list_queue_slots(
-        profile_id: str, queue_id: str = "", all: str = ""
-    ) -> str:
+    def queue_list_queue_slots(profile_id: str, queue_id: str = "", all: str = "") -> str:
         """List schedules
 
         Args:
@@ -3043,17 +2354,14 @@ def register_generated_tools(mcp, _get_client):
             all: Set to 'true' to list all queues for the profile"""
         client = _get_client()
         try:
-            response = client.queue.list_queue_slots(
-                profile_id=profile_id, queue_id=queue_id, all=all
-            )
+            response = client.queue.list_queue_slots(profile_id=profile_id, queue_id=queue_id, all=all)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def queue_create_queue_slot(
-        profile_id: str, name: str, timezone: str, slots: str, active: bool = True
-    ) -> str:
+    def queue_create_queue_slot(profile_id: str, name: str, timezone: str, slots: str, active: bool = True) -> str:
         """Create schedule
 
         Args:
@@ -3064,28 +2372,14 @@ def register_generated_tools(mcp, _get_client):
             active"""
         client = _get_client()
         try:
-            response = client.queue.create_queue_slot(
-                profileId=profile_id,
-                name=name,
-                timezone=timezone,
-                slots=slots,
-                active=active,
-            )
+            response = client.queue.create_queue_slot(profile_id=profile_id, name=name, timezone=timezone, slots=slots, active=active)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def queue_update_queue_slot(
-        profile_id: str,
-        timezone: str,
-        slots: str,
-        queue_id: str = "",
-        name: str = "",
-        active: bool = True,
-        set_as_default: bool = False,
-        reshuffle_existing: bool = False,
-    ) -> str:
+    def queue_update_queue_slot(profile_id: str, timezone: str, slots: str, queue_id: str = "", name: str = "", active: bool = True, set_as_default: bool = False, reshuffle_existing: bool = False) -> str:
         """Update schedule
 
         Args:
@@ -3099,19 +2393,11 @@ def register_generated_tools(mcp, _get_client):
             reshuffle_existing: Whether to reschedule existing queued posts to match new slots"""
         client = _get_client()
         try:
-            response = client.queue.update_queue_slot(
-                profileId=profile_id,
-                queueId=queue_id,
-                name=name,
-                timezone=timezone,
-                slots=slots,
-                active=active,
-                setAsDefault=set_as_default,
-                reshuffleExisting=reshuffle_existing,
-            )
+            response = client.queue.update_queue_slot(profile_id=profile_id, queue_id=queue_id, name=name, timezone=timezone, slots=slots, active=active, set_as_default=set_as_default, reshuffle_existing=reshuffle_existing)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def queue_delete_queue_slot(profile_id: str, queue_id: str) -> str:
@@ -3122,17 +2408,14 @@ def register_generated_tools(mcp, _get_client):
             queue_id: Queue ID to delete (required)"""
         client = _get_client()
         try:
-            response = client.queue.delete_queue_slot(
-                profile_id=profile_id, queue_id=queue_id
-            )
+            response = client.queue.delete_queue_slot(profile_id=profile_id, queue_id=queue_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def queue_preview_queue(
-        profile_id: str, queue_id: str = "", count: int = 20
-    ) -> str:
+    def queue_preview_queue(profile_id: str, queue_id: str = "", count: int = 20) -> str:
         """Preview upcoming slots
 
         Args:
@@ -3141,12 +2424,11 @@ def register_generated_tools(mcp, _get_client):
             count"""
         client = _get_client()
         try:
-            response = client.queue.preview_queue(
-                profile_id=profile_id, queue_id=queue_id, count=count
-            )
+            response = client.queue.preview_queue(profile_id=profile_id, queue_id=queue_id, count=count)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def queue_get_next_queue_slot(profile_id: str, queue_id: str = "") -> str:
@@ -3157,25 +2439,16 @@ def register_generated_tools(mcp, _get_client):
             queue_id: Specific queue ID (optional, defaults to profile's default queue)"""
         client = _get_client()
         try:
-            response = client.queue.get_next_queue_slot(
-                profile_id=profile_id, queue_id=queue_id
-            )
+            response = client.queue.get_next_queue_slot(profile_id=profile_id, queue_id=queue_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # REDDIT
 
+
     @mcp.tool()
-    def reddit_search_reddit(
-        account_id: str,
-        q: str,
-        subreddit: str = "",
-        restrict_sr: str = "",
-        sort: str = "new",
-        limit: int = 25,
-        after: str = "",
-    ) -> str:
+    def reddit_search_reddit(account_id: str, q: str, subreddit: str = "", restrict_sr: str = "", sort: str = "new", limit: int = 25, after: str = "") -> str:
         """Search posts
 
         Args:
@@ -3188,28 +2461,14 @@ def register_generated_tools(mcp, _get_client):
             after"""
         client = _get_client()
         try:
-            response = client.reddit.search_reddit(
-                account_id=account_id,
-                subreddit=subreddit,
-                q=q,
-                restrict_sr=restrict_sr,
-                sort=sort,
-                limit=limit,
-                after=after,
-            )
+            response = client.reddit.search_reddit(account_id=account_id, subreddit=subreddit, q=q, restrict_sr=restrict_sr, sort=sort, limit=limit, after=after)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def reddit_get_reddit_feed(
-        account_id: str,
-        subreddit: str = "",
-        sort: str = "hot",
-        limit: int = 25,
-        after: str = "",
-        t: str = "",
-    ) -> str:
+    def reddit_get_reddit_feed(account_id: str, subreddit: str = "", sort: str = "hot", limit: int = 25, after: str = "", t: str = "") -> str:
         """Get subreddit feed
 
         Args:
@@ -3221,33 +2480,16 @@ def register_generated_tools(mcp, _get_client):
             t"""
         client = _get_client()
         try:
-            response = client.reddit.get_reddit_feed(
-                account_id=account_id,
-                subreddit=subreddit,
-                sort=sort,
-                limit=limit,
-                after=after,
-                t=t,
-            )
+            response = client.reddit.get_reddit_feed(account_id=account_id, subreddit=subreddit, sort=sort, limit=limit, after=after, t=t)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # REVIEWS
 
+
     @mcp.tool()
-    def reviews_list_inbox_reviews(
-        profile_id: str = "",
-        platform: str = "",
-        min_rating: int = 0,
-        max_rating: int = 0,
-        has_reply: bool = False,
-        sort_by: str = "date",
-        sort_order: str = "desc",
-        limit: int = 25,
-        cursor: str = "",
-        account_id: str = "",
-    ) -> str:
+    def reviews_list_inbox_reviews(profile_id: str = "", platform: str = "", min_rating: int = 0, max_rating: int = 0, has_reply: bool = False, sort_by: str = "date", sort_order: str = "desc", limit: int = 25, cursor: str = "", account_id: str = "") -> str:
         """List reviews
 
         Args:
@@ -3263,26 +2505,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: Filter by specific social account ID"""
         client = _get_client()
         try:
-            response = client.reviews.list_inbox_reviews(
-                profile_id=profile_id,
-                platform=platform,
-                min_rating=min_rating,
-                max_rating=max_rating,
-                has_reply=has_reply,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                limit=limit,
-                cursor=cursor,
-                account_id=account_id,
-            )
+            response = client.reviews.list_inbox_reviews(profile_id=profile_id, platform=platform, min_rating=min_rating, max_rating=max_rating, has_reply=has_reply, sort_by=sort_by, sort_order=sort_order, limit=limit, cursor=cursor, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def reviews_reply_to_inbox_review(
-        review_id: str, account_id: str, message: str
-    ) -> str:
+    def reviews_reply_to_inbox_review(review_id: str, account_id: str, message: str) -> str:
         """Reply to review
 
         Args:
@@ -3291,12 +2521,11 @@ def register_generated_tools(mcp, _get_client):
             message: (required)"""
         client = _get_client()
         try:
-            response = client.reviews.reply_to_inbox_review(
-                review_id=review_id, accountId=account_id, message=message
-            )
+            response = client.reviews.reply_to_inbox_review(review_id=review_id, account_id=account_id, message=message)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def reviews_delete_inbox_review_reply(review_id: str, account_id: str) -> str:
@@ -3307,19 +2536,16 @@ def register_generated_tools(mcp, _get_client):
             account_id: (required)"""
         client = _get_client()
         try:
-            response = client.reviews.delete_inbox_review_reply(
-                review_id=review_id, accountId=account_id
-            )
+            response = client.reviews.delete_inbox_review_reply(review_id=review_id, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # SEQUENCES
 
+
     @mcp.tool()
-    def sequences_list_sequences(
-        profile_id: str = "", status: str = "", limit: int = 50, skip: int = 0
-    ) -> str:
+    def sequences_list_sequences(profile_id: str = "", status: str = "", limit: int = 50, skip: int = 0) -> str:
         """List sequences
 
         Args:
@@ -3329,24 +2555,14 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.sequences.list_sequences(
-                profile_id=profile_id, status=status, limit=limit, skip=skip
-            )
+            response = client.sequences.list_sequences(profile_id=profile_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def sequences_create_sequence(
-        profile_id: str,
-        account_id: str,
-        platform: str,
-        name: str,
-        description: str = "",
-        steps: str = "",
-        exit_on_reply: bool = True,
-        exit_on_unsubscribe: bool = True,
-    ) -> str:
+    def sequences_create_sequence(profile_id: str, account_id: str, platform: str, name: str, description: str = "", steps: str = "", exit_on_reply: bool = True, exit_on_unsubscribe: bool = True) -> str:
         """Create a sequence
 
         Args:
@@ -3360,19 +2576,11 @@ def register_generated_tools(mcp, _get_client):
             exit_on_unsubscribe"""
         client = _get_client()
         try:
-            response = client.sequences.create_sequence(
-                profileId=profile_id,
-                accountId=account_id,
-                platform=platform,
-                name=name,
-                description=description,
-                steps=steps,
-                exitOnReply=exit_on_reply,
-                exitOnUnsubscribe=exit_on_unsubscribe,
-            )
+            response = client.sequences.create_sequence(profile_id=profile_id, account_id=account_id, platform=platform, name=name, description=description, steps=steps, exit_on_reply=exit_on_reply, exit_on_unsubscribe=exit_on_unsubscribe)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_get_sequence(sequence_id: str) -> str:
@@ -3385,7 +2593,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.sequences.get_sequence(sequence_id=sequence_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_update_sequence(sequence_id: str) -> str:
@@ -3398,7 +2607,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.sequences.update_sequence(sequence_id=sequence_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_delete_sequence(sequence_id: str) -> str:
@@ -3411,7 +2621,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.sequences.delete_sequence(sequence_id=sequence_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_activate_sequence(sequence_id: str) -> str:
@@ -3424,7 +2635,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.sequences.activate_sequence(sequence_id=sequence_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_pause_sequence(sequence_id: str) -> str:
@@ -3437,12 +2649,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.sequences.pause_sequence(sequence_id=sequence_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def sequences_enroll_contacts(
-        sequence_id: str, contact_ids: str, channel_ids: str = ""
-    ) -> str:
+    def sequences_enroll_contacts(sequence_id: str, contact_ids: str, channel_ids: str = "") -> str:
         """Enroll contacts in a sequence
 
         Args:
@@ -3451,12 +2662,11 @@ def register_generated_tools(mcp, _get_client):
             channel_ids: Optional. Auto-detected if not provided."""
         client = _get_client()
         try:
-            response = client.sequences.enroll_contacts(
-                sequence_id=sequence_id, contactIds=contact_ids, channelIds=channel_ids
-            )
+            response = client.sequences.enroll_contacts(sequence_id=sequence_id, contact_ids=contact_ids, channel_ids=channel_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def sequences_unenroll_contact(sequence_id: str, contact_id: str) -> str:
@@ -3467,17 +2677,14 @@ def register_generated_tools(mcp, _get_client):
             contact_id: (required)"""
         client = _get_client()
         try:
-            response = client.sequences.unenroll_contact(
-                sequence_id=sequence_id, contact_id=contact_id
-            )
+            response = client.sequences.unenroll_contact(sequence_id=sequence_id, contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def sequences_list_sequence_enrollments(
-        sequence_id: str, status: str = "", limit: int = 50, skip: int = 0
-    ) -> str:
+    def sequences_list_sequence_enrollments(sequence_id: str, status: str = "", limit: int = 50, skip: int = 0) -> str:
         """List enrollments for a sequence
 
         Args:
@@ -3487,23 +2694,16 @@ def register_generated_tools(mcp, _get_client):
             skip"""
         client = _get_client()
         try:
-            response = client.sequences.list_sequence_enrollments(
-                sequence_id=sequence_id, status=status, limit=limit, skip=skip
-            )
+            response = client.sequences.list_sequence_enrollments(sequence_id=sequence_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # TOOLS
 
+
     @mcp.tool()
-    def tools_download_you_tube_video(
-        url: str,
-        action: str = "download",
-        format: str = "video",
-        quality: str = "hd",
-        format_id: str = "",
-    ) -> str:
+    def tools_download_you_tube_video(url: str, action: str = "download", format: str = "video", quality: str = "hd", format_id: str = "") -> str:
         """Download YouTube video
 
         Args:
@@ -3514,16 +2714,11 @@ def register_generated_tools(mcp, _get_client):
             format_id: Specific format ID from formats list"""
         client = _get_client()
         try:
-            response = client.tools.download_you_tube_video(
-                url=url,
-                action=action,
-                format=format,
-                quality=quality,
-                format_id=format_id,
-            )
+            response = client.tools.download_you_tube_video(url=url, action=action, format=format, quality=quality, format_id=format_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_get_you_tube_transcript(url: str, lang: str = "en") -> str:
@@ -3537,7 +2732,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.get_you_tube_transcript(url=url, lang=lang)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_download_instagram_media(url: str) -> str:
@@ -3550,7 +2746,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.download_instagram_media(url=url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_check_instagram_hashtags(hashtags: str) -> str:
@@ -3563,12 +2760,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.check_instagram_hashtags(hashtags=hashtags)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def tools_download_tik_tok_video(
-        url: str, action: str = "download", format_id: str = ""
-    ) -> str:
+    def tools_download_tik_tok_video(url: str, action: str = "download", format_id: str = "") -> str:
         """Download TikTok video
 
         Args:
@@ -3577,17 +2773,14 @@ def register_generated_tools(mcp, _get_client):
             format_id: Specific format ID (0 = no watermark, etc.)"""
         client = _get_client()
         try:
-            response = client.tools.download_tik_tok_video(
-                url=url, action=action, format_id=format_id
-            )
+            response = client.tools.download_tik_tok_video(url=url, action=action, format_id=format_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def tools_download_twitter_media(
-        url: str, action: str = "download", format_id: str = ""
-    ) -> str:
+    def tools_download_twitter_media(url: str, action: str = "download", format_id: str = "") -> str:
         """Download Twitter/X media
 
         Args:
@@ -3596,12 +2789,11 @@ def register_generated_tools(mcp, _get_client):
             format_id"""
         client = _get_client()
         try:
-            response = client.tools.download_twitter_media(
-                url=url, action=action, format_id=format_id
-            )
+            response = client.tools.download_twitter_media(url=url, action=action, format_id=format_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_download_facebook_video(url: str) -> str:
@@ -3614,7 +2806,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.download_facebook_video(url=url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_download_linked_in_video(url: str) -> str:
@@ -3627,7 +2820,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.download_linked_in_video(url=url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def tools_download_bluesky_media(url: str) -> str:
@@ -3640,9 +2834,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.tools.download_bluesky_media(url=url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # TWITTER_ENGAGEMENT
+
 
     @mcp.tool()
     def twitter_engagement_retweet_post(account_id: str, tweet_id: str) -> str:
@@ -3653,12 +2848,11 @@ def register_generated_tools(mcp, _get_client):
             tweet_id: The ID of the tweet to retweet (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.retweet_post(
-                accountId=account_id, tweetId=tweet_id
-            )
+            response = client.twitter_engagement.retweet_post(account_id=account_id, tweet_id=tweet_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def twitter_engagement_undo_retweet(account_id: str, tweet_id: str) -> str:
@@ -3669,12 +2863,11 @@ def register_generated_tools(mcp, _get_client):
             tweet_id: The ID of the original tweet to un-retweet (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.undo_retweet(
-                account_id=account_id, tweet_id=tweet_id
-            )
+            response = client.twitter_engagement.undo_retweet(account_id=account_id, tweet_id=tweet_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def twitter_engagement_bookmark_post(account_id: str, tweet_id: str) -> str:
@@ -3685,12 +2878,11 @@ def register_generated_tools(mcp, _get_client):
             tweet_id: The ID of the tweet to bookmark (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.bookmark_post(
-                accountId=account_id, tweetId=tweet_id
-            )
+            response = client.twitter_engagement.bookmark_post(account_id=account_id, tweet_id=tweet_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def twitter_engagement_remove_bookmark(account_id: str, tweet_id: str) -> str:
@@ -3701,12 +2893,11 @@ def register_generated_tools(mcp, _get_client):
             tweet_id: The ID of the tweet to unbookmark (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.remove_bookmark(
-                account_id=account_id, tweet_id=tweet_id
-            )
+            response = client.twitter_engagement.remove_bookmark(account_id=account_id, tweet_id=tweet_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def twitter_engagement_follow_user(account_id: str, target_user_id: str) -> str:
@@ -3717,12 +2908,11 @@ def register_generated_tools(mcp, _get_client):
             target_user_id: The Twitter ID of the user to follow (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.follow_user(
-                accountId=account_id, targetUserId=target_user_id
-            )
+            response = client.twitter_engagement.follow_user(account_id=account_id, target_user_id=target_user_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def twitter_engagement_unfollow_user(account_id: str, target_user_id: str) -> str:
@@ -3733,14 +2923,13 @@ def register_generated_tools(mcp, _get_client):
             target_user_id: The Twitter ID of the user to unfollow (required)"""
         client = _get_client()
         try:
-            response = client.twitter_engagement.unfollow_user(
-                account_id=account_id, target_user_id=target_user_id
-            )
+            response = client.twitter_engagement.unfollow_user(account_id=account_id, target_user_id=target_user_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # USAGE
+
 
     @mcp.tool()
     def usage_get_usage_stats() -> str:
@@ -3750,9 +2939,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.usage.get_usage_stats()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # USERS
+
 
     @mcp.tool()
     def users_list_users() -> str:
@@ -3762,7 +2952,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.users.list_users()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def users_get_user(user_id: str) -> str:
@@ -3775,9 +2966,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.users.get_user(user_id=user_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # VALIDATE
+
 
     @mcp.tool()
     def validate_post_length(text: str) -> str:
@@ -3790,7 +2982,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.validate.validate_post_length(text=text)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def validate_post(platforms: str, content: str = "", media_items: str = "") -> str:
@@ -3802,12 +2995,11 @@ def register_generated_tools(mcp, _get_client):
             media_items: Root media items shared across platforms"""
         client = _get_client()
         try:
-            response = client.validate.validate_post(
-                content=content, platforms=platforms, mediaItems=media_items
-            )
+            response = client.validate.validate_post(content=content, platforms=platforms, media_items=media_items)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def validate_media(url: str) -> str:
@@ -3820,7 +3012,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.validate.validate_media(url=url)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def validate_subreddit(name: str) -> str:
@@ -3833,9 +3026,10 @@ def register_generated_tools(mcp, _get_client):
             response = client.validate.validate_subreddit(name=name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # WEBHOOKS
+
 
     @mcp.tool()
     def webhooks_get_webhook_settings() -> str:
@@ -3845,17 +3039,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.webhooks.get_webhook_settings()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def webhooks_create_webhook_settings(
-        name: str = "",
-        url: str = "",
-        secret: str = "",
-        events: str = "",
-        is_active: bool = False,
-        custom_headers: str = "",
-    ) -> str:
+    def webhooks_create_webhook_settings(name: str = "", url: str = "", secret: str = "", events: str = "", is_active: bool = False, custom_headers: str = "") -> str:
         """Create webhook
 
         Args:
@@ -3867,28 +3055,14 @@ def register_generated_tools(mcp, _get_client):
             custom_headers: Custom headers to include in webhook requests"""
         client = _get_client()
         try:
-            response = client.webhooks.create_webhook_settings(
-                name=name,
-                url=url,
-                secret=secret,
-                events=events,
-                isActive=is_active,
-                customHeaders=custom_headers,
-            )
+            response = client.webhooks.create_webhook_settings(name=name, url=url, secret=secret, events=events, is_active=is_active, custom_headers=custom_headers)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def webhooks_update_webhook_settings(
-        id: str,
-        name: str = "",
-        url: str = "",
-        secret: str = "",
-        events: str = "",
-        is_active: bool = False,
-        custom_headers: str = "",
-    ) -> str:
+    def webhooks_update_webhook_settings(id: str, name: str = "", url: str = "", secret: str = "", events: str = "", is_active: bool = False, custom_headers: str = "") -> str:
         """Update webhook
 
         Args:
@@ -3901,18 +3075,11 @@ def register_generated_tools(mcp, _get_client):
             custom_headers: Custom headers to include in webhook requests"""
         client = _get_client()
         try:
-            response = client.webhooks.update_webhook_settings(
-                _id=id,
-                name=name,
-                url=url,
-                secret=secret,
-                events=events,
-                isActive=is_active,
-                customHeaders=custom_headers,
-            )
+            response = client.webhooks.update_webhook_settings(id=id, name=name, url=url, secret=secret, events=events, is_active=is_active, custom_headers=custom_headers)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def webhooks_delete_webhook_settings(id: str) -> str:
@@ -3925,7 +3092,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.webhooks.delete_webhook_settings(id=id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def webhooks_test_webhook(webhook_id: str) -> str:
@@ -3935,15 +3103,14 @@ def register_generated_tools(mcp, _get_client):
             webhook_id: ID of the webhook to test (required)"""
         client = _get_client()
         try:
-            response = client.webhooks.test_webhook(webhookId=webhook_id)
+            response = client.webhooks.test_webhook(webhook_id=webhook_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def webhooks_get_webhook_logs(
-        limit: int = 50, status: str = "", event: str = "", webhook_id: str = ""
-    ) -> str:
+    def webhooks_get_webhook_logs(limit: int = 50, status: str = "", event: str = "", webhook_id: str = "") -> str:
         """Get delivery logs
 
         Args:
@@ -3953,19 +3120,16 @@ def register_generated_tools(mcp, _get_client):
             webhook_id: Filter by webhook ID"""
         client = _get_client()
         try:
-            response = client.webhooks.get_webhook_logs(
-                limit=limit, status=status, event=event, webhook_id=webhook_id
-            )
+            response = client.webhooks.get_webhook_logs(limit=limit, status=status, event=event, webhook_id=webhook_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # WHATSAPP
 
+
     @mcp.tool()
-    def whatsapp_send_whats_app_bulk(
-        account_id: str, recipients: str, template: str
-    ) -> str:
+    def whatsapp_send_whats_app_bulk(account_id: str, recipients: str, template: str) -> str:
         """Bulk send template messages
 
         Args:
@@ -3974,23 +3138,14 @@ def register_generated_tools(mcp, _get_client):
             template: (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.send_whats_app_bulk(
-                accountId=account_id, recipients=recipients, template=template
-            )
+            response = client.whatsapp.send_whats_app_bulk(account_id=account_id, recipients=recipients, template=template)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_get_whats_app_contacts(
-        account_id: str,
-        search: str = "",
-        tag: str = "",
-        group: str = "",
-        opted_in: str = "",
-        limit: int = 50,
-        skip: int = 0,
-    ) -> str:
+    def whatsapp_get_whats_app_contacts(account_id: str, search: str = "", tag: str = "", group: str = "", opted_in: str = "", limit: int = 50, skip: int = 0) -> str:
         """List contacts
 
         Args:
@@ -4003,32 +3158,14 @@ def register_generated_tools(mcp, _get_client):
             skip: Offset for pagination"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_contacts(
-                account_id=account_id,
-                search=search,
-                tag=tag,
-                group=group,
-                opted_in=opted_in,
-                limit=limit,
-                skip=skip,
-            )
+            response = client.whatsapp.get_whats_app_contacts(account_id=account_id, search=search, tag=tag, group=group, opted_in=opted_in, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_create_whats_app_contact(
-        account_id: str,
-        phone: str,
-        name: str,
-        email: str = "",
-        company: str = "",
-        tags: str = "",
-        groups: str = "",
-        is_opted_in: bool = True,
-        custom_fields: str = "",
-        notes: str = "",
-    ) -> str:
+    def whatsapp_create_whats_app_contact(account_id: str, phone: str, name: str, email: str = "", company: str = "", tags: str = "", groups: str = "", is_opted_in: bool = True, custom_fields: str = "", notes: str = "") -> str:
         """Create contact
 
         Args:
@@ -4044,21 +3181,11 @@ def register_generated_tools(mcp, _get_client):
             notes: Notes about the contact"""
         client = _get_client()
         try:
-            response = client.whatsapp.create_whats_app_contact(
-                accountId=account_id,
-                phone=phone,
-                name=name,
-                email=email,
-                company=company,
-                tags=tags,
-                groups=groups,
-                isOptedIn=is_opted_in,
-                customFields=custom_fields,
-                notes=notes,
-            )
+            response = client.whatsapp.create_whats_app_contact(account_id=account_id, phone=phone, name=name, email=email, company=company, tags=tags, groups=groups, is_opted_in=is_opted_in, custom_fields=custom_fields, notes=notes)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_contact(contact_id: str) -> str:
@@ -4071,21 +3198,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.get_whats_app_contact(contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_update_whats_app_contact(
-        contact_id: str,
-        name: str = "",
-        email: str = "",
-        company: str = "",
-        tags: str = "",
-        groups: str = "",
-        is_opted_in: bool = False,
-        is_blocked: bool = False,
-        custom_fields: str = "",
-        notes: str = "",
-    ) -> str:
+    def whatsapp_update_whats_app_contact(contact_id: str, name: str = "", email: str = "", company: str = "", tags: str = "", groups: str = "", is_opted_in: bool = False, is_blocked: bool = False, custom_fields: str = "", notes: str = "") -> str:
         """Update contact
 
         Args:
@@ -4101,21 +3218,11 @@ def register_generated_tools(mcp, _get_client):
             notes: Notes about the contact"""
         client = _get_client()
         try:
-            response = client.whatsapp.update_whats_app_contact(
-                contact_id=contact_id,
-                name=name,
-                email=email,
-                company=company,
-                tags=tags,
-                groups=groups,
-                isOptedIn=is_opted_in,
-                isBlocked=is_blocked,
-                customFields=custom_fields,
-                notes=notes,
-            )
+            response = client.whatsapp.update_whats_app_contact(contact_id=contact_id, name=name, email=email, company=company, tags=tags, groups=groups, is_opted_in=is_opted_in, is_blocked=is_blocked, custom_fields=custom_fields, notes=notes)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_delete_whats_app_contact(contact_id: str) -> str:
@@ -4128,16 +3235,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.delete_whats_app_contact(contact_id=contact_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_import_whats_app_contacts(
-        account_id: str,
-        contacts: str,
-        default_tags: str = "",
-        default_groups: str = "",
-        skip_duplicates: bool = True,
-    ) -> str:
+    def whatsapp_import_whats_app_contacts(account_id: str, contacts: str, default_tags: str = "", default_groups: str = "", skip_duplicates: bool = True) -> str:
         """Bulk import contacts
 
         Args:
@@ -4148,21 +3250,14 @@ def register_generated_tools(mcp, _get_client):
             skip_duplicates: Skip contacts with existing phone numbers"""
         client = _get_client()
         try:
-            response = client.whatsapp.import_whats_app_contacts(
-                accountId=account_id,
-                contacts=contacts,
-                defaultTags=default_tags,
-                defaultGroups=default_groups,
-                skipDuplicates=skip_duplicates,
-            )
+            response = client.whatsapp.import_whats_app_contacts(account_id=account_id, contacts=contacts, default_tags=default_tags, default_groups=default_groups, skip_duplicates=skip_duplicates)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_bulk_update_whats_app_contacts(
-        action: str, contact_ids: str, tags: str = "", groups: str = ""
-    ) -> str:
+    def whatsapp_bulk_update_whats_app_contacts(action: str, contact_ids: str, tags: str = "", groups: str = "") -> str:
         """Bulk update contacts
 
         Args:
@@ -4172,12 +3267,11 @@ def register_generated_tools(mcp, _get_client):
             groups: Groups to add or remove (required for addGroups/removeGroups)"""
         client = _get_client()
         try:
-            response = client.whatsapp.bulk_update_whats_app_contacts(
-                action=action, contactIds=contact_ids, tags=tags, groups=groups
-            )
+            response = client.whatsapp.bulk_update_whats_app_contacts(action=action, contact_ids=contact_ids, tags=tags, groups=groups)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_bulk_delete_whats_app_contacts(contact_ids: str) -> str:
@@ -4187,12 +3281,11 @@ def register_generated_tools(mcp, _get_client):
             contact_ids: Contact IDs to delete (max 500) (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.bulk_delete_whats_app_contacts(
-                contactIds=contact_ids
-            )
+            response = client.whatsapp.bulk_delete_whats_app_contacts(contact_ids=contact_ids)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_groups(account_id: str) -> str:
@@ -4205,12 +3298,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.get_whats_app_groups(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_rename_whats_app_group(
-        account_id: str, old_name: str, new_name: str
-    ) -> str:
+    def whatsapp_rename_whats_app_group(account_id: str, old_name: str, new_name: str) -> str:
         """Rename group
 
         Args:
@@ -4219,12 +3311,11 @@ def register_generated_tools(mcp, _get_client):
             new_name: New group name (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.rename_whats_app_group(
-                accountId=account_id, oldName=old_name, newName=new_name
-            )
+            response = client.whatsapp.rename_whats_app_group(account_id=account_id, old_name=old_name, new_name=new_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_delete_whats_app_group(account_id: str, group_name: str) -> str:
@@ -4235,12 +3326,11 @@ def register_generated_tools(mcp, _get_client):
             group_name: Group name to delete (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.delete_whats_app_group(
-                accountId=account_id, groupName=group_name
-            )
+            response = client.whatsapp.delete_whats_app_group(account_id=account_id, group_name=group_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_templates(account_id: str) -> str:
@@ -4253,50 +3343,34 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.get_whats_app_templates(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_create_whats_app_template(
-        account_id: str,
-        name: str,
-        category: str,
-        language: str,
-        components: str = "",
-        library_template_name: str = "",
-        library_template_body_inputs: str = "",
-        library_template_button_inputs: str = "",
-    ) -> str:
+    def whatsapp_create_whats_app_template(account_id: str, name: str, category: str, language: str, components: str = "", library_template_name: str = "", library_template_body_inputs: str = "", library_template_button_inputs: str = "") -> str:
         """Create template
 
-            Args:
-                account_id: WhatsApp social account ID (required)
-                name: Template name (lowercase, letters/numbers/underscores, must start with a letter) (required)
-                category: Template category (required)
-                language: Template language code (e.g., en_US) (required)
-                components: Template components (header, body, footer, buttons). Required for custom templates, omit when using library_template_name.
-                library_template_name: Name of a pre-built template from Meta's template library (e.g., "appointment_reminder",
-        "auto_pay_reminder_1", "address_update"). When provided, the template is pre-approved
-        by Meta with no review wait. Omit `components` when using this field.
-                library_template_body_inputs: Optional body customizations for library templates. Available options depend on the
-        template (e.g., add_contact_number, add_learn_more_link, add_security_recommendation,
-        add_track_package_link, code_expiration_minutes).
-                library_template_button_inputs: Optional button customizations for library templates. Each item specifies button type
-        and configuration (e.g., URL, phone number, quick reply)."""
+        Args:
+            account_id: WhatsApp social account ID (required)
+            name: Template name (lowercase, letters/numbers/underscores, must start with a letter) (required)
+            category: Template category (required)
+            language: Template language code (e.g., en_US) (required)
+            components: Template components (header, body, footer, buttons). Required for custom templates, omit when using library_template_name.
+            library_template_name: Name of a pre-built template from Meta's template library (e.g., "appointment_reminder",
+    "auto_pay_reminder_1", "address_update"). When provided, the template is pre-approved
+    by Meta with no review wait. Omit `components` when using this field.
+            library_template_body_inputs: Optional body customizations for library templates. Available options depend on the
+    template (e.g., add_contact_number, add_learn_more_link, add_security_recommendation,
+    add_track_package_link, code_expiration_minutes).
+            library_template_button_inputs: Optional button customizations for library templates. Each item specifies button type
+    and configuration (e.g., URL, phone number, quick reply)."""
         client = _get_client()
         try:
-            response = client.whatsapp.create_whats_app_template(
-                accountId=account_id,
-                name=name,
-                category=category,
-                language=language,
-                components=components,
-                library_template_name=library_template_name,
-                library_template_body_inputs=library_template_body_inputs,
-                library_template_button_inputs=library_template_button_inputs,
-            )
+            response = client.whatsapp.create_whats_app_template(account_id=account_id, name=name, category=category, language=language, components=components, library_template_name=library_template_name, library_template_body_inputs=library_template_body_inputs, library_template_button_inputs=library_template_button_inputs)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_template(template_name: str, account_id: str) -> str:
@@ -4307,17 +3381,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: WhatsApp social account ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_template(
-                template_name=template_name, account_id=account_id
-            )
+            response = client.whatsapp.get_whats_app_template(template_name=template_name, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_update_whats_app_template(
-        template_name: str, account_id: str, components: str
-    ) -> str:
+    def whatsapp_update_whats_app_template(template_name: str, account_id: str, components: str) -> str:
         """Update template
 
         Args:
@@ -4326,12 +3397,11 @@ def register_generated_tools(mcp, _get_client):
             components: Updated template components (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.update_whats_app_template(
-                template_name=template_name, accountId=account_id, components=components
-            )
+            response = client.whatsapp.update_whats_app_template(template_name=template_name, account_id=account_id, components=components)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_delete_whats_app_template(template_name: str, account_id: str) -> str:
@@ -4342,17 +3412,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: WhatsApp social account ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.delete_whats_app_template(
-                template_name=template_name, account_id=account_id
-            )
+            response = client.whatsapp.delete_whats_app_template(template_name=template_name, account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_get_whats_app_broadcasts(
-        account_id: str, status: str = "", limit: int = 50, skip: int = 0
-    ) -> str:
+    def whatsapp_get_whats_app_broadcasts(account_id: str, status: str = "", limit: int = 50, skip: int = 0) -> str:
         """List broadcasts
 
         Args:
@@ -4362,21 +3429,14 @@ def register_generated_tools(mcp, _get_client):
             skip: Offset for pagination"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_broadcasts(
-                account_id=account_id, status=status, limit=limit, skip=skip
-            )
+            response = client.whatsapp.get_whats_app_broadcasts(account_id=account_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_create_whats_app_broadcast(
-        account_id: str,
-        name: str,
-        template: str,
-        description: str = "",
-        recipients: str = "",
-    ) -> str:
+    def whatsapp_create_whats_app_broadcast(account_id: str, name: str, template: str, description: str = "", recipients: str = "") -> str:
         """Create broadcast
 
         Args:
@@ -4387,16 +3447,11 @@ def register_generated_tools(mcp, _get_client):
             recipients: Initial recipients (optional)"""
         client = _get_client()
         try:
-            response = client.whatsapp.create_whats_app_broadcast(
-                accountId=account_id,
-                name=name,
-                description=description,
-                template=template,
-                recipients=recipients,
-            )
+            response = client.whatsapp.create_whats_app_broadcast(account_id=account_id, name=name, description=description, template=template, recipients=recipients)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_broadcast(broadcast_id: str) -> str:
@@ -4406,12 +3461,11 @@ def register_generated_tools(mcp, _get_client):
             broadcast_id: Broadcast ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_broadcast(
-                broadcast_id=broadcast_id
-            )
+            response = client.whatsapp.get_whats_app_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_delete_whats_app_broadcast(broadcast_id: str) -> str:
@@ -4421,12 +3475,11 @@ def register_generated_tools(mcp, _get_client):
             broadcast_id: Broadcast ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.delete_whats_app_broadcast(
-                broadcast_id=broadcast_id
-            )
+            response = client.whatsapp.delete_whats_app_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_send_whats_app_broadcast(broadcast_id: str) -> str:
@@ -4436,17 +3489,14 @@ def register_generated_tools(mcp, _get_client):
             broadcast_id: Broadcast ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.send_whats_app_broadcast(
-                broadcast_id=broadcast_id
-            )
+            response = client.whatsapp.send_whats_app_broadcast(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_schedule_whats_app_broadcast(
-        broadcast_id: str, scheduled_at: str
-    ) -> str:
+    def whatsapp_schedule_whats_app_broadcast(broadcast_id: str, scheduled_at: str) -> str:
         """Schedule broadcast
 
         Args:
@@ -4454,12 +3504,11 @@ def register_generated_tools(mcp, _get_client):
             scheduled_at: ISO 8601 date-time for sending (must be in the future, max 30 days) (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.schedule_whats_app_broadcast(
-                broadcast_id=broadcast_id, scheduledAt=scheduled_at
-            )
+            response = client.whatsapp.schedule_whats_app_broadcast(broadcast_id=broadcast_id, scheduled_at=scheduled_at)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_cancel_whats_app_broadcast_schedule(broadcast_id: str) -> str:
@@ -4469,17 +3518,14 @@ def register_generated_tools(mcp, _get_client):
             broadcast_id: Broadcast ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.cancel_whats_app_broadcast_schedule(
-                broadcast_id=broadcast_id
-            )
+            response = client.whatsapp.cancel_whats_app_broadcast_schedule(broadcast_id=broadcast_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_get_whats_app_broadcast_recipients(
-        broadcast_id: str, status: str = "", limit: int = 100, skip: int = 0
-    ) -> str:
+    def whatsapp_get_whats_app_broadcast_recipients(broadcast_id: str, status: str = "", limit: int = 100, skip: int = 0) -> str:
         """List recipients
 
         Args:
@@ -4489,17 +3535,14 @@ def register_generated_tools(mcp, _get_client):
             skip: Offset for pagination"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_broadcast_recipients(
-                broadcast_id=broadcast_id, status=status, limit=limit, skip=skip
-            )
+            response = client.whatsapp.get_whats_app_broadcast_recipients(broadcast_id=broadcast_id, status=status, limit=limit, skip=skip)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_add_whats_app_broadcast_recipients(
-        broadcast_id: str, recipients: str
-    ) -> str:
+    def whatsapp_add_whats_app_broadcast_recipients(broadcast_id: str, recipients: str) -> str:
         """Add recipients
 
         Args:
@@ -4507,17 +3550,14 @@ def register_generated_tools(mcp, _get_client):
             recipients: Recipients to add (max 1000) (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.add_whats_app_broadcast_recipients(
-                broadcast_id=broadcast_id, recipients=recipients
-            )
+            response = client.whatsapp.add_whats_app_broadcast_recipients(broadcast_id=broadcast_id, recipients=recipients)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_remove_whats_app_broadcast_recipients(
-        broadcast_id: str, phones: str
-    ) -> str:
+    def whatsapp_remove_whats_app_broadcast_recipients(broadcast_id: str, phones: str) -> str:
         """Remove recipients
 
         Args:
@@ -4525,12 +3565,11 @@ def register_generated_tools(mcp, _get_client):
             phones: Phone numbers to remove (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.remove_whats_app_broadcast_recipients(
-                broadcast_id=broadcast_id, phones=phones
-            )
+            response = client.whatsapp.remove_whats_app_broadcast_recipients(broadcast_id=broadcast_id, phones=phones)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_business_profile(account_id: str) -> str:
@@ -4540,24 +3579,14 @@ def register_generated_tools(mcp, _get_client):
             account_id: WhatsApp social account ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.get_whats_app_business_profile(
-                account_id=account_id
-            )
+            response = client.whatsapp.get_whats_app_business_profile(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_update_whats_app_business_profile(
-        account_id: str,
-        about: str = "",
-        address: str = "",
-        description: str = "",
-        email: str = "",
-        websites: str = "",
-        vertical: str = "",
-        profile_picture_handle: str = "",
-    ) -> str:
+    def whatsapp_update_whats_app_business_profile(account_id: str, about: str = "", address: str = "", description: str = "", email: str = "", websites: str = "", vertical: str = "", profile_picture_handle: str = "") -> str:
         """Update business profile
 
         Args:
@@ -4571,19 +3600,11 @@ def register_generated_tools(mcp, _get_client):
             profile_picture_handle: Handle from resumable upload for profile picture"""
         client = _get_client()
         try:
-            response = client.whatsapp.update_whats_app_business_profile(
-                accountId=account_id,
-                about=about,
-                address=address,
-                description=description,
-                email=email,
-                websites=websites,
-                vertical=vertical,
-                profilePictureHandle=profile_picture_handle,
-            )
+            response = client.whatsapp.update_whats_app_business_profile(account_id=account_id, about=about, address=address, description=description, email=email, websites=websites, vertical=vertical, profile_picture_handle=profile_picture_handle)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_upload_whats_app_profile_photo() -> str:
@@ -4593,7 +3614,8 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.upload_whats_app_profile_photo()
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_get_whats_app_display_name(account_id: str) -> str:
@@ -4606,12 +3628,11 @@ def register_generated_tools(mcp, _get_client):
             response = client.whatsapp.get_whats_app_display_name(account_id=account_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_update_whats_app_display_name(
-        account_id: str, display_name: str
-    ) -> str:
+    def whatsapp_update_whats_app_display_name(account_id: str, display_name: str) -> str:
         """Request display name change
 
         Args:
@@ -4619,19 +3640,16 @@ def register_generated_tools(mcp, _get_client):
             display_name: New display name (must follow WhatsApp naming guidelines) (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp.update_whats_app_display_name(
-                accountId=account_id, displayName=display_name
-            )
+            response = client.whatsapp.update_whats_app_display_name(account_id=account_id, display_name=display_name)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
 
     # WHATSAPP_PHONE_NUMBERS
 
+
     @mcp.tool()
-    def whatsapp_phone_numbers_get_whats_app_phone_numbers(
-        status: str = "", profile_id: str = ""
-    ) -> str:
+    def whatsapp_phone_numbers_get_whats_app_phone_numbers(status: str = "", profile_id: str = "") -> str:
         """List phone numbers
 
         Args:
@@ -4639,12 +3657,11 @@ def register_generated_tools(mcp, _get_client):
             profile_id: Filter by profile"""
         client = _get_client()
         try:
-            response = client.whatsapp_phone_numbers.get_whats_app_phone_numbers(
-                status=status, profile_id=profile_id
-            )
+            response = client.whatsapp_phone_numbers.get_whats_app_phone_numbers(status=status, profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_phone_numbers_purchase_whats_app_phone_number(profile_id: str) -> str:
@@ -4654,12 +3671,11 @@ def register_generated_tools(mcp, _get_client):
             profile_id: Profile to associate the number with (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp_phone_numbers.purchase_whats_app_phone_number(
-                profileId=profile_id
-            )
+            response = client.whatsapp_phone_numbers.purchase_whats_app_phone_number(profile_id=profile_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
     def whatsapp_phone_numbers_get_whats_app_phone_number(phone_number_id: str) -> str:
@@ -4669,26 +3685,21 @@ def register_generated_tools(mcp, _get_client):
             phone_number_id: Phone number record ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp_phone_numbers.get_whats_app_phone_number(
-                phone_number_id=phone_number_id
-            )
+            response = client.whatsapp_phone_numbers.get_whats_app_phone_number(phone_number_id=phone_number_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'
+
 
     @mcp.tool()
-    def whatsapp_phone_numbers_release_whats_app_phone_number(
-        phone_number_id: str,
-    ) -> str:
+    def whatsapp_phone_numbers_release_whats_app_phone_number(phone_number_id: str) -> str:
         """Release phone number
 
         Args:
             phone_number_id: Phone number record ID (required)"""
         client = _get_client()
         try:
-            response = client.whatsapp_phone_numbers.release_whats_app_phone_number(
-                phone_number_id=phone_number_id
-            )
+            response = client.whatsapp_phone_numbers.release_whats_app_phone_number(phone_number_id=phone_number_id)
             return _format_response(response)
         except Exception as e:
-            return f"Error: {e}"
+            return f'Error: {e}'


### PR DESCRIPTION
## Summary
- **One-line fix** in `scripts/generate_mcp_tools.py`: request body params were using raw camelCase OpenAPI property names as `sdk_name` instead of the snake_case conversion, causing all MCP tools with body params to fail
- Regenerated `src/late/mcp/generated_tools.py` with correct snake_case kwargs
- Fixes 169 incorrect camelCase kwargs across ~29 MCP tool methods

## Bug
Reported by customer (Multiverse Beans). When calling `comments_reply_to_inbox_post`, the MCP layer passed `accountId=...` but the SDK method expects `account_id=...`:
```
CommentsResource.reply_to_inbox_post() got an unexpected keyword argument 'accountId'. Did you mean 'account_id'?
```

## Root cause
In `extract_parameters()`, the request body branch set `"sdk_name": prop_name` (camelCase from OpenAPI) instead of `"sdk_name": py_name` (snake_case). Query/path params were already correct.

## Test plan
- [ ] Verify `comments_reply_to_inbox_post` works with Reddit accounts
- [ ] Spot-check other MCP tools with body params (e.g. post creation, webhooks)
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)