### PR TITLE
fix: regenerate SDK and fix broken model imports

### DIFF
--- a/src/late/models/__init__.py
+++ b/src/late/models/__init__.py
@@ -13,14 +13,9 @@ from ._generated.models import (
     AccountGetResponse,
     AccountsListResponse,
     AccountWithFollowerStats,
-    CaptionResponse,
-    DownloadFormat,
-    DownloadResponse,
     ErrorResponse,
     FacebookPlatformData,
     FollowerStatsResponse,
-    HashtagCheckResponse,
-    HashtagInfo,
     InstagramPlatformData,
     LinkedInPlatformData,
     MediaItem,
@@ -51,8 +46,6 @@ from ._generated.models import (
     SocialAccount,
     Status,
     TikTokPlatformData,
-    TranscriptResponse,
-    TranscriptSegment,
     TwitterPlatformData,
     Type,
     UploadedFile,
@@ -73,7 +66,14 @@ from ._generated.models import (
 
 # SDK-specific models (not from OpenAPI)
 from .responses import (
+    CaptionResponse,
+    DownloadFormat,
+    DownloadResponse,
+    HashtagCheckResponse,
+    HashtagInfo,
     MediaLargeUploadResponse,
+    TranscriptResponse,
+    TranscriptSegment,
 )
 
 __all__ = [

--- a/src/late/models/responses.py
+++ b/src/late/models/responses.py
@@ -7,7 +7,63 @@ For API response models, see the generated models in _generated/models.py.
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from enum import Enum
+
+from pydantic import AnyUrl, BaseModel
+
+# ---------------------------------------------------------------------------
+# Tools endpoint models (endpoints removed from OpenAPI spec but still
+# functional for existing customers)
+# ---------------------------------------------------------------------------
+
+
+class DownloadFormat(BaseModel):
+    formatId: str | None = None
+    ext: str | None = None
+    resolution: str | None = None
+    filesize: int | None = None
+    quality: str | None = None
+
+
+class DownloadResponse(BaseModel):
+    url: AnyUrl | None = None
+    title: str | None = None
+    thumbnail: AnyUrl | None = None
+    duration: int | None = None
+    formats: list[DownloadFormat] | None = None
+
+
+class TranscriptSegment(BaseModel):
+    text: str | None = None
+    start: float | None = None
+    duration: float | None = None
+
+
+class TranscriptResponse(BaseModel):
+    transcript: str | None = None
+    segments: list[TranscriptSegment] | None = None
+    language: str | None = None
+
+
+class HashtagStatus(str, Enum):
+    SAFE = "safe"
+    BANNED = "banned"
+    RESTRICTED = "restricted"
+    UNKNOWN = "unknown"
+
+
+class HashtagInfo(BaseModel):
+    hashtag: str | None = None
+    status: HashtagStatus | None = None
+    postCount: int | None = None
+
+
+class HashtagCheckResponse(BaseModel):
+    hashtags: list[HashtagInfo] | None = None
+
+
+class CaptionResponse(BaseModel):
+    caption: str | None = None
 
 
 class MediaLargeUploadResponse(BaseModel):

--- a/src/late/resources/tools.py
+++ b/src/late/resources/tools.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from late.models import (
+from late.models.responses import (
     CaptionResponse,
     DownloadResponse,
     HashtagCheckResponse,

--- a/tests/test_exhaustive.py
+++ b/tests/test_exhaustive.py
@@ -271,13 +271,12 @@ class TestModelsValidation:
         assert Status.FAILED.value == "failed"
 
     def test_type_enum_values(self):
-        """Test Type5 (media type) enum has expected values."""
-        from late.models._generated.models import Type5
+        """Test MediaItem type field accepts media types."""
+        from late.models._generated.models import MediaItem
 
-        assert hasattr(Type5, "IMAGE")
-        assert hasattr(Type5, "VIDEO")
-        assert Type5.IMAGE.value == "image"
-        assert Type5.VIDEO.value == "video"
+        MediaType = MediaItem.model_fields["type"].annotation
+        assert MediaItem(type="image").type.value == "image"
+        assert MediaItem(type="video").type.value == "video"
 
     def test_tiktok_settings_creation(self):
         """Test TikTokPlatformData model creation."""
@@ -294,10 +293,10 @@ class TestModelsValidation:
 
     def test_media_item_creation(self):
         """Test MediaItem with type enum."""
-        from late.models._generated.models import MediaItem, Type5
+        from late.models._generated.models import MediaItem
 
-        item = MediaItem(type=Type5.IMAGE)
-        assert item.type == Type5.IMAGE
+        item = MediaItem(type="image")
+        assert item.type.value == "image"
 
 
 # ============================================================================

--- a/tests/test_exhaustive.py
+++ b/tests/test_exhaustive.py
@@ -271,13 +271,13 @@ class TestModelsValidation:
         assert Status.FAILED.value == "failed"
 
     def test_type_enum_values(self):
-        """Test Type enum has expected values."""
-        from late.models import Type
+        """Test Type5 (media type) enum has expected values."""
+        from late.models._generated.models import Type5
 
-        assert hasattr(Type, "IMAGE")
-        assert hasattr(Type, "VIDEO")
-        assert Type.IMAGE.value == "image"
-        assert Type.VIDEO.value == "video"
+        assert hasattr(Type5, "IMAGE")
+        assert hasattr(Type5, "VIDEO")
+        assert Type5.IMAGE.value == "image"
+        assert Type5.VIDEO.value == "video"
 
     def test_tiktok_settings_creation(self):
         """Test TikTokPlatformData model creation."""
@@ -294,11 +294,10 @@ class TestModelsValidation:
 
     def test_media_item_creation(self):
         """Test MediaItem with type enum."""
-        from late.models import Type
-        from late.models._generated.models import MediaItem
+        from late.models._generated.models import MediaItem, Type5
 
-        item = MediaItem(type=Type.IMAGE)
-        assert item.type == Type.IMAGE
+        item = MediaItem(type=Type5.IMAGE)
+        assert item.type == Type5.IMAGE
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Regenerated SDK from latest OpenAPI spec (resources, models, MCP tools, README)
- Moved 7 removed-from-spec models (`CaptionResponse`, `DownloadResponse`, `DownloadFormat`, `HashtagCheckResponse`, `HashtagInfo`, `TranscriptResponse`, `TranscriptSegment`) to `responses.py` as SDK-specific models — the endpoints still work for existing customers
- Fixed pre-existing test failures where `Type` enum was renamed to `Type5` in the generated models

## Test plan
- [x] `uv run ruff check src tests` — passed
- [x] `uv run mypy src --ignore-missing-imports` — 0 issues (88 files)
- [x] `uv run pytest tests -v --tb=short` — 159 passed, 14 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)