### PR TITLE
fix(mcp/http): advertise Bearer scheme on 401 (RFC 6750)

### DIFF
--- a/src/late/mcp/routes.py
+++ b/src/late/mcp/routes.py
@@ -71,18 +71,25 @@ def create_sse_handler(mcp_server, sse_transport: SseServerTransport, debug: boo
     async def handle_sse(request: Request) -> Response:
         """Handle SSE connection with authentication."""
         # Extract API key from request
+        # 401 responses include `WWW-Authenticate: Bearer realm="zernio-mcp"` per
+        # RFC 6750 so spec-compliant MCP clients (mcp-remote, etc.) know this is
+        # static Bearer auth and don't fall back to OAuth discovery — see the
+        # docstring on `_send_json_error` below for the full rationale.
+        bearer_challenge = {"WWW-Authenticate": 'Bearer realm="zernio-mcp"'}
         api_key = extract_late_api_key(request)
         if not api_key:
             return JSONResponse(
                 {"error": "Missing API key. Provide via Authorization header: 'Authorization: Bearer YOUR_API_KEY'"},
-                status_code=401
+                status_code=401,
+                headers=bearer_challenge,
             )
 
         # Verify API key by making test request
         if not await verify_late_api_key(api_key):
             return JSONResponse(
                 {"error": "Invalid API key"},
-                status_code=401
+                status_code=401,
+                headers=bearer_challenge,
             )
 
         # Store API key in request state for use in MCP tools
@@ -124,8 +131,17 @@ async def _send_json_error(scope: Scope, receive: Receive, send: Send, status: i
     Used by the Streamable HTTP wrapper because the session manager expects
     a raw ASGI callable, not a Starlette endpoint — so we can't just `return
     JSONResponse(...)` from the wrapper.
+
+    On 401 we add `WWW-Authenticate: Bearer realm="zernio-mcp"` per RFC 6750.
+    Without this header, MCP clients like `mcp-remote` interpret the 401 as
+    "OAuth required" and probe `/.well-known/oauth-authorization-server`,
+    which 404s here (we use static API-key auth, not OAuth) and surfaces to
+    the user as a confusing JSON parse error. Advertising the bearer scheme
+    tells spec-compliant clients to send the static Bearer token they
+    already have and skip OAuth discovery entirely.
     """
-    response = JSONResponse({"error": message}, status_code=status)
+    headers = {"WWW-Authenticate": 'Bearer realm="zernio-mcp"'} if status == 401 else None
+    response = JSONResponse({"error": message}, status_code=status, headers=headers)
     await response(scope, receive, send)
 
 


### PR DESCRIPTION
## Summary
- Without `WWW-Authenticate: Bearer realm="zernio-mcp"` on 401, MCP clients like `mcp-remote` interpret the 401 as "OAuth required" and probe `/.well-known/oauth-authorization-server`. That 404s with plain-text "Not Found" and surfaces to the user as `HTTP 404: Invalid OAuth error response: SyntaxError: Unexpected token 'N', 'Not Found' is not valid JSON.`
- This server uses static API-key auth, not OAuth. Per RFC 6750 we should advertise the bearer scheme on 401 so clients send their static token and skip OAuth discovery.
- Applied to both 401 paths: the SSE handler (`handle_sse`) and the Streamable HTTP wrapper (`_send_json_error`, used by `StreamableHTTPAuthHandler`).

## Why this surfaced
A Windows user (Claude Desktop + `mcp-remote`) reported `HTTP 404: Invalid OAuth error response` even after pasting our documented `mcp-remote` config. The root cause was a missing Authorization header (env-var indirection broken on Windows), but the 404 came from this `WWW-Authenticate` gap. Fixing it means even malformed bearer setups fail cleanly with the "Missing API key" JSON we already return, instead of leading clients into an OAuth-discovery dead end.

## Test plan
- [ ] `curl -i https://mcp.zernio.com/mcp` returns `401` with `WWW-Authenticate: Bearer realm="zernio-mcp"`
- [ ] `curl -i https://mcp.zernio.com/sse` returns the same
- [ ] `curl -i -H 'Authorization: Bearer not-a-real-key' https://mcp.zernio.com/mcp` returns `401 {"error":"Invalid API key"}` with the same header
- [ ] `npx mcp-remote@latest https://mcp.zernio.com/mcp --header "Authorization: Bearer sk_<real_key>"` connects and lists tools without OAuth-discovery noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)