### PR TITLE
fix(client): align User-Agent with installed SDK version

### DIFF
--- a/src/late/client/base.py
+++ b/src/late/client/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import time
 from contextlib import asynccontextmanager, contextmanager
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -25,6 +26,15 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
 
+def _resolve_sdk_version() -> str:
+    for dist_name in ("zernio-sdk", "late-sdk"):
+        try:
+            return version(dist_name)
+        except PackageNotFoundError:
+            continue
+    return "0.0.0+unknown"
+
+
 class BaseClient:
     """
     Base HTTP client supporting both sync and async operations.
@@ -36,7 +46,7 @@ class BaseClient:
     DEFAULT_BASE_URL = "https://zernio.com/api"
     DEFAULT_TIMEOUT = 30.0
     DEFAULT_MAX_RETRIES = 3
-    SDK_VERSION = "1.0.0"
+    SDK_VERSION = _resolve_sdk_version()
 
     def __init__(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,12 @@
 """Tests for Late client."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 import pytest
 
 from late import Late
+from late.client import base as base_module
+from late.client.base import BaseClient
 
 
 class TestLateClient:
@@ -35,6 +39,38 @@ class TestLateClient:
         assert hasattr(client, "analytics")
         assert hasattr(client, "tools")
         assert hasattr(client, "queue")
+
+
+class TestUserAgent:
+    """User-Agent must reflect the installed package version, not a hardcoded value."""
+
+    def _installed_version(self) -> str:
+        for dist_name in ("zernio-sdk", "late-sdk"):
+            try:
+                return version(dist_name)
+            except PackageNotFoundError:
+                continue
+        pytest.fail("Neither zernio-sdk nor late-sdk is installed")
+
+    def test_sdk_version_matches_installed_distribution(self) -> None:
+        assert self._installed_version() == BaseClient.SDK_VERSION
+
+    def test_sdk_version_is_not_the_old_hardcoded_value(self) -> None:
+        # Regression guard: User-Agent used to be pinned at 1.0.0 forever.
+        assert BaseClient.SDK_VERSION != "1.0.0"
+
+    def test_user_agent_header_uses_resolved_version(self, api_key: str) -> None:
+        client = BaseClient(api_key=api_key)
+        assert client._headers["User-Agent"] == f"late-python-sdk/{self._installed_version()}"
+
+    def test_resolve_sdk_version_falls_back_when_no_distribution_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _always_missing(_name: str) -> str:
+            raise PackageNotFoundError
+
+        monkeypatch.setattr(base_module, "version", _always_missing)
+        assert base_module._resolve_sdk_version() == "0.0.0+unknown"
 
 
 class TestModels:


### PR DESCRIPTION
## Summary
- Replace hardcoded `SDK_VERSION = \"1.0.0\"` in `BaseClient` with a lookup via `importlib.metadata.version()`, trying `zernio-sdk` then `late-sdk` (the package ships under both names).
- `User-Agent` header now reads `late-python-sdk/<actual-installed-version>` instead of always `late-python-sdk/1.0.0`. No workflow change needed — `pyproject.toml` remains the single source of truth and `generate.yml` already bumps it.

## Test plan
- [x] `uv run pytest tests` → 171 passed, 14 skipped
- [x] `uv run ruff check src/late/client/base.py` → clean
- [x] Manual check: `BaseClient(api_key='test')._headers['User-Agent']` → `late-python-sdk/1.4.67` (matches `pyproject.toml`)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)