### PR TITLE
fix(resources): forward query params on write requests (GBP locationId)

### DIFF
--- a/scripts/generate_resources.py
+++ b/scripts/generate_resources.py
@@ -275,11 +275,12 @@ def generate_method_body(
         path_expr = f'f"{path_formatted}"'
 
     # Determine if we need query params based on HTTP method
-    # GET and DELETE use query params; POST/PUT/PATCH typically use body
+    # GET and DELETE use query params; POST/PUT/PATCH carry a body but may ALSO
+    # carry query params (e.g. GBP writes take the payload in the body plus a
+    # locationId query param). Both must be forwarded, not one or the other.
     use_query_params = http_method.upper() in ("GET", "DELETE") and query_params
     use_body_params = http_method.upper() in ("POST", "PUT", "PATCH") and body_params
-    # POST can also have query params in URL
-    use_query_on_post = http_method.upper() in ("POST", "PUT", "PATCH") and query_params and not body_params
+    use_query_on_post = http_method.upper() in ("POST", "PUT", "PATCH") and query_params
 
     # Build params dict if needed
     if use_query_params or use_query_on_post:
@@ -307,12 +308,14 @@ def generate_method_body(
         else:
             lines.append(f"        return {await_prefix}self._client.{client_method}({path_expr})")
     else:  # POST, PUT, PATCH
+        call_args = [path_expr]
         if body_params:
-            lines.append(f"        return {await_prefix}self._client.{client_method}({path_expr}, data=payload)")
-        elif query_params:
-            lines.append(f"        return {await_prefix}self._client.{client_method}({path_expr}, params=params)")
-        else:
-            lines.append(f"        return {await_prefix}self._client.{client_method}({path_expr})")
+            call_args.append("data=payload")
+        if query_params:
+            call_args.append("params=params")
+        lines.append(
+            f"        return {await_prefix}self._client.{client_method}({', '.join(call_args)})"
+        )
 
     return lines
 

--- a/src/late/client/base.py
+++ b/src/late/client/base.py
@@ -235,10 +235,20 @@ class BaseClient:
         self,
         path: str,
         data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Make a sync PUT request."""
+        """Make a sync PUT request.
+
+        Accepts both ``data`` (JSON body) and ``params`` (query string). Some
+        write endpoints take a body plus query params, e.g. GBP updates carry
+        the payload in the body and a ``locationId`` query param that selects
+        which location the write targets; without it the API falls back to the
+        account's stored location.
+        """
         with self._sync_client() as client:
-            return self._request_with_retry(client, "PUT", path, json=data)
+            return self._request_with_retry(
+                client, "PUT", path, json=data, params=params
+            )
 
     def _patch(
         self,
@@ -362,10 +372,20 @@ class BaseClient:
         self,
         path: str,
         data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Make an async PUT request."""
+        """Make an async PUT request.
+
+        Accepts both ``data`` (JSON body) and ``params`` (query string). Some
+        write endpoints take a body plus query params, e.g. GBP updates carry
+        the payload in the body and a ``locationId`` query param that selects
+        which location the write targets; without it the API falls back to the
+        account's stored location.
+        """
         async with self._async_client() as client:
-            return await self._arequest_with_retry(client, "PUT", path, json=data)
+            return await self._arequest_with_retry(
+                client, "PUT", path, json=data, params=params
+            )
 
     async def _apatch(
         self,

--- a/src/late/resources/_generated/accounts.py
+++ b/src/late/resources/_generated/accounts.py
@@ -191,12 +191,15 @@ class AccountsResource:
         update_mask: str | None = None,
     ) -> dict[str, Any]:
         """Update food menus"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             menus=menus,
             update_mask=update_mask,
         )
         return self._client._put(
-            f"/v1/accounts/{account_id}/gmb-food-menus", data=payload
+            f"/v1/accounts/{account_id}/gmb-food-menus", data=payload, params=params
         )
 
     def get_google_business_location_details(
@@ -230,6 +233,9 @@ class AccountsResource:
         service_items: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Update location details"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             update_mask=update_mask,
             regular_hours=regular_hours,
@@ -241,7 +247,9 @@ class AccountsResource:
             service_items=service_items,
         )
         return self._client._put(
-            f"/v1/accounts/{account_id}/gmb-location-details", data=payload
+            f"/v1/accounts/{account_id}/gmb-location-details",
+            data=payload,
+            params=params,
         )
 
     def list_google_business_media(
@@ -271,13 +279,18 @@ class AccountsResource:
         category: str | None = None,
     ) -> dict[str, Any]:
         """Upload photo"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             source_url=source_url,
             media_format=media_format,
             description=description,
             category=category,
         )
-        return self._client._post(f"/v1/accounts/{account_id}/gmb-media", data=payload)
+        return self._client._post(
+            f"/v1/accounts/{account_id}/gmb-media", data=payload, params=params
+        )
 
     def delete_google_business_media(
         self, account_id: str, media_id: str, *, location_id: str | None = None
@@ -335,12 +348,15 @@ class AccountsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Update attributes"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             attributes=attributes,
             attribute_mask=attribute_mask,
         )
         return self._client._put(
-            f"/v1/accounts/{account_id}/gmb-attributes", data=payload
+            f"/v1/accounts/{account_id}/gmb-attributes", data=payload, params=params
         )
 
     def list_google_business_place_actions(
@@ -370,12 +386,15 @@ class AccountsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Create action link"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             uri=uri,
             place_action_type=place_action_type,
         )
         return self._client._post(
-            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload
+            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload, params=params
         )
 
     def delete_google_business_place_action(
@@ -400,13 +419,16 @@ class AccountsResource:
         place_action_type: str | None = None,
     ) -> dict[str, Any]:
         """Update action link"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             name=name,
             uri=uri,
             place_action_type=place_action_type,
         )
         return self._client._patch(
-            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload
+            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload, params=params
         )
 
     def batch_get_google_business_reviews(
@@ -595,12 +617,15 @@ class AccountsResource:
         update_mask: str | None = None,
     ) -> dict[str, Any]:
         """Update food menus (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             menus=menus,
             update_mask=update_mask,
         )
         return await self._client._aput(
-            f"/v1/accounts/{account_id}/gmb-food-menus", data=payload
+            f"/v1/accounts/{account_id}/gmb-food-menus", data=payload, params=params
         )
 
     async def aget_google_business_location_details(
@@ -634,6 +659,9 @@ class AccountsResource:
         service_items: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Update location details (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             update_mask=update_mask,
             regular_hours=regular_hours,
@@ -645,7 +673,9 @@ class AccountsResource:
             service_items=service_items,
         )
         return await self._client._aput(
-            f"/v1/accounts/{account_id}/gmb-location-details", data=payload
+            f"/v1/accounts/{account_id}/gmb-location-details",
+            data=payload,
+            params=params,
         )
 
     async def alist_google_business_media(
@@ -677,6 +707,9 @@ class AccountsResource:
         category: str | None = None,
     ) -> dict[str, Any]:
         """Upload photo (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             source_url=source_url,
             media_format=media_format,
@@ -684,7 +717,7 @@ class AccountsResource:
             category=category,
         )
         return await self._client._apost(
-            f"/v1/accounts/{account_id}/gmb-media", data=payload
+            f"/v1/accounts/{account_id}/gmb-media", data=payload, params=params
         )
 
     async def adelete_google_business_media(
@@ -743,12 +776,15 @@ class AccountsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Update attributes (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             attributes=attributes,
             attribute_mask=attribute_mask,
         )
         return await self._client._aput(
-            f"/v1/accounts/{account_id}/gmb-attributes", data=payload
+            f"/v1/accounts/{account_id}/gmb-attributes", data=payload, params=params
         )
 
     async def alist_google_business_place_actions(
@@ -778,12 +814,15 @@ class AccountsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Create action link (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             uri=uri,
             place_action_type=place_action_type,
         )
         return await self._client._apost(
-            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload
+            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload, params=params
         )
 
     async def adelete_google_business_place_action(
@@ -808,13 +847,16 @@ class AccountsResource:
         place_action_type: str | None = None,
     ) -> dict[str, Any]:
         """Update action link (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             name=name,
             uri=uri,
             place_action_type=place_action_type,
         )
         return await self._client._apatch(
-            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload
+            f"/v1/accounts/{account_id}/gmb-place-actions", data=payload, params=params
         )
 
     async def abatch_get_google_business_reviews(

--- a/src/late/resources/_generated/gmb_services.py
+++ b/src/late/resources/_generated/gmb_services.py
@@ -73,11 +73,14 @@ class GmbServicesResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Replace services"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             service_items=service_items,
         )
         return self._client._put(
-            f"/v1/accounts/{account_id}/gmb-services", data=payload
+            f"/v1/accounts/{account_id}/gmb-services", data=payload, params=params
         )
 
     async def aget_google_business_services(
@@ -99,9 +102,12 @@ class GmbServicesResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Replace services (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             service_items=service_items,
         )
         return await self._client._aput(
-            f"/v1/accounts/{account_id}/gmb-services", data=payload
+            f"/v1/accounts/{account_id}/gmb-services", data=payload, params=params
         )

--- a/src/late/resources/_generated/gmb_verifications.py
+++ b/src/late/resources/_generated/gmb_verifications.py
@@ -78,6 +78,9 @@ class GmbVerificationsResource:
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Start a verification"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             method=method,
             language_code=language_code,
@@ -87,7 +90,7 @@ class GmbVerificationsResource:
             context=context,
         )
         return self._client._post(
-            f"/v1/accounts/{account_id}/gmb-verifications", data=payload
+            f"/v1/accounts/{account_id}/gmb-verifications", data=payload, params=params
         )
 
     def fetch_google_business_verification_options(
@@ -99,12 +102,17 @@ class GmbVerificationsResource:
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Fetch verification options"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             language_code=language_code,
             context=context,
         )
         return self._client._post(
-            f"/v1/accounts/{account_id}/gmb-verifications/options", data=payload
+            f"/v1/accounts/{account_id}/gmb-verifications/options",
+            data=payload,
+            params=params,
         )
 
     def complete_google_business_verification(
@@ -116,12 +124,16 @@ class GmbVerificationsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Complete a verification"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             pin=pin,
         )
         return self._client._post(
             f"/v1/accounts/{account_id}/gmb-verifications/{verification_id}/complete",
             data=payload,
+            params=params,
         )
 
     async def aget_google_business_verifications(
@@ -148,6 +160,9 @@ class GmbVerificationsResource:
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Start a verification (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             method=method,
             language_code=language_code,
@@ -157,7 +172,7 @@ class GmbVerificationsResource:
             context=context,
         )
         return await self._client._apost(
-            f"/v1/accounts/{account_id}/gmb-verifications", data=payload
+            f"/v1/accounts/{account_id}/gmb-verifications", data=payload, params=params
         )
 
     async def afetch_google_business_verification_options(
@@ -169,12 +184,17 @@ class GmbVerificationsResource:
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Fetch verification options (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             language_code=language_code,
             context=context,
         )
         return await self._client._apost(
-            f"/v1/accounts/{account_id}/gmb-verifications/options", data=payload
+            f"/v1/accounts/{account_id}/gmb-verifications/options",
+            data=payload,
+            params=params,
         )
 
     async def acomplete_google_business_verification(
@@ -186,10 +206,14 @@ class GmbVerificationsResource:
         location_id: str | None = None,
     ) -> dict[str, Any]:
         """Complete a verification (async)"""
+        params = self._build_params(
+            location_id=location_id,
+        )
         payload = self._build_payload(
             pin=pin,
         )
         return await self._client._apost(
             f"/v1/accounts/{account_id}/gmb-verifications/{verification_id}/complete",
             data=payload,
+            params=params,
         )

--- a/src/late/resources/_generated/whatsapp.py
+++ b/src/late/resources/_generated/whatsapp.py
@@ -310,12 +310,17 @@ class WhatsappResource:
         join_approval_mode: str | None = None,
     ) -> dict[str, Any]:
         """Update group settings"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             subject=subject,
             description=description,
             join_approval_mode=join_approval_mode,
         )
-        return self._client._post(f"/v1/whatsapp/wa-groups/{group_id}", data=payload)
+        return self._client._post(
+            f"/v1/whatsapp/wa-groups/{group_id}", data=payload, params=params
+        )
 
     def delete_whats_app_group_chat(
         self, group_id: str, account_id: str
@@ -330,11 +335,16 @@ class WhatsappResource:
         self, group_id: str, account_id: str, phone_numbers: list[str]
     ) -> dict[str, Any]:
         """Add participants"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             phone_numbers=phone_numbers,
         )
         return self._client._post(
-            f"/v1/whatsapp/wa-groups/{group_id}/participants", data=payload
+            f"/v1/whatsapp/wa-groups/{group_id}/participants",
+            data=payload,
+            params=params,
         )
 
     def remove_whats_app_group_participants(
@@ -374,11 +384,16 @@ class WhatsappResource:
         self, group_id: str, account_id: str, phone_numbers: list[str]
     ) -> dict[str, Any]:
         """Approve join requests"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             phone_numbers=phone_numbers,
         )
         return self._client._post(
-            f"/v1/whatsapp/wa-groups/{group_id}/join-requests", data=payload
+            f"/v1/whatsapp/wa-groups/{group_id}/join-requests",
+            data=payload,
+            params=params,
         )
 
     def reject_whats_app_group_join_requests(
@@ -699,13 +714,16 @@ class WhatsappResource:
         join_approval_mode: str | None = None,
     ) -> dict[str, Any]:
         """Update group settings (async)"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             subject=subject,
             description=description,
             join_approval_mode=join_approval_mode,
         )
         return await self._client._apost(
-            f"/v1/whatsapp/wa-groups/{group_id}", data=payload
+            f"/v1/whatsapp/wa-groups/{group_id}", data=payload, params=params
         )
 
     async def adelete_whats_app_group_chat(
@@ -723,11 +741,16 @@ class WhatsappResource:
         self, group_id: str, account_id: str, phone_numbers: list[str]
     ) -> dict[str, Any]:
         """Add participants (async)"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             phone_numbers=phone_numbers,
         )
         return await self._client._apost(
-            f"/v1/whatsapp/wa-groups/{group_id}/participants", data=payload
+            f"/v1/whatsapp/wa-groups/{group_id}/participants",
+            data=payload,
+            params=params,
         )
 
     async def aremove_whats_app_group_participants(
@@ -767,11 +790,16 @@ class WhatsappResource:
         self, group_id: str, account_id: str, phone_numbers: list[str]
     ) -> dict[str, Any]:
         """Approve join requests (async)"""
+        params = self._build_params(
+            account_id=account_id,
+        )
         payload = self._build_payload(
             phone_numbers=phone_numbers,
         )
         return await self._client._apost(
-            f"/v1/whatsapp/wa-groups/{group_id}/join-requests", data=payload
+            f"/v1/whatsapp/wa-groups/{group_id}/join-requests",
+            data=payload,
+            params=params,
         )
 
     async def areject_whats_app_group_join_requests(


### PR DESCRIPTION
## Why

GBP write endpoints silently dropped the `locationId` query param, so edits (attributes update, services replace, etc.) executed against the account's default/selected location instead of the one requested. The write still returned `200`, so a caller trusting the success status could modify a different location's live listing (a cross-tenant write in agency workspaces). Root cause is entirely in the SDK: it never forwarded query params on write requests that also carried a body.

## What

- `client/base.py`: `_put`/`_aput` now accept and forward `params`. A PUT could not carry a query string at all before (unlike `_patch`, which already did).
- `scripts/generate_resources.py`: the generator now emits the body **and** the query params together on POST/PUT/PATCH. It used to pick one (`data` when a body existed, `params` otherwise), so any write with both dropped the query param.
- Regenerated resources. Writes that carry a body plus a query param now forward it:
  - GBP (`locationId`): attributes, services, food-menus, media, place-actions, verifications.
  - WhatsApp group writes (`accountId`): same bug class, fixed by the same change.

Tests: 176 passed, 14 skipped. Ruff clean on the changed files (the pre-existing generator warnings are unchanged).

## Follow-ups

- This fix makes the `locationId` travel; separately, the Zernio API could fail-closed on writes that arrive without an explicit location instead of falling back to the default (defensive hardening).
- The `PUT gmb-services` 500 the same customer hit is a separate API-side issue (a Google `400 INVALID_ARGUMENT` masked as a 500) and is not addressed here.
