### PR TITLE
ci: notify zernio-mcp after SDK publication

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -192,3 +192,14 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+
+      - name: Trigger MCP SDK Sync
+        if: steps.changes.outputs.has_changes == 'true'
+        continue-on-error: true
+        run: |
+          curl -fsS -L -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.MCP_DISPATCH_TOKEN }}" \
+            https://api.github.com/repos/zernio-dev/zernio-mcp/dispatches \
+            -d '{"event_type":"sdk-released","client_payload":{"sdk_version":"${{ steps.version.outputs.new_version }}","ref":"${{ github.sha }}"}}'
+          echo "✓ Triggered MCP sync for ${{ steps.version.outputs.new_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,17 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+      - name: Trigger MCP SDK Sync
+        if: steps.check_tag.outputs.exists == 'false'
+        continue-on-error: true
+        run: |
+          curl -fsS -L -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.MCP_DISPATCH_TOKEN }}" \
+            https://api.github.com/repos/zernio-dev/zernio-mcp/dispatches \
+            -d '{"event_type":"sdk-released","client_payload":{"sdk_version":"${{ steps.version.outputs.version }}","ref":"${{ github.sha }}"}}'
+          echo "✓ Triggered MCP sync for ${{ steps.version.outputs.version }}"
+
       - name: Post-release Summary
         if: steps.check_tag.outputs.exists == 'false'
         run: |


### PR DESCRIPTION
## Why

When the SDK publishes to PyPI, nothing tells `zernio-mcp` about it. The MCP package sits on an old SDK version until someone notices by hand.

## What

A `repository_dispatch` at the end of both publish pipelines, using the same curl pattern as the Node SDK trigger in the API repo:

```yaml
- name: Trigger MCP SDK Sync
  if: <same condition as the publish steps above>
  continue-on-error: true
  run: |
    curl -fsS -L -X POST \
      -H "Accept: application/vnd.github.v3+json" \
      -H "Authorization: token ${{ secrets.MCP_DISPATCH_TOKEN }}" \
      https://api.github.com/repos/zernio-dev/zernio-mcp/dispatches \
      -d '{"event_type":"sdk-released","client_payload":{"sdk_version":"...","ref":"${{ github.sha }}"}}'
```

`sdk-released` + `sdk_version` is what `zernio-mcp/.github/workflows/sync-sdk.yml` listens for and validates. Each step reuses the condition of the publish steps above it, so a run that published nothing notifies nothing.

Workflow files only — no source, tests, or packaging.

## Worth a look

- **Secret:** `MCP_DISPATCH_TOKEN`, already configured. (#29 assumes `MCP_REPO_TOKEN`, which does not exist here.)
- **`-fsS`:** the reference snippet omits `-f`, so a 401 exits 0 and still prints `✓ Triggered`. With `-f` the step goes red while `continue-on-error` keeps the release green. Easy to drop.
- **`release.yml` will not actually fire.** It runs only on push to `main` (1.4.49 vs develop's 1.4.291, untouched since May), and its last run skipped every publish step because the tag already existed. Added for symmetry and manual releases; `generate.yml` is what notifies MCP in practice.
- **Out of scope:** `generate.yml`'s publish steps still have `continue-on-error: true`, so a failed upload fires the dispatch anyway. #29 removes those two lines — needs to land there or as a follow-up.
- **Conflicts with #29** on both files; whichever merges second needs a rebase.

## Validation

YAML parses; dispatch payload is valid JSON and passes the semver regex `sync-sdk.yml` enforces; referenced step ids/outputs exist; notify step sits after both publishes with a matching condition. Not yet run against the live pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)